### PR TITLE
Various improvements

### DIFF
--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -17,7 +17,6 @@ pub fn get_encoder(bytes: &[u8], rg_encoding: &RgEncoding) -> (Option<Bom>, Enco
         .or_else(|| rg_encoding.encoder())
         // nothing so far, try detecting the encoding
         .or_else(|| {
-            // TODO: use chardet::UniversalDetector to detect using a reader rather than a whole slice
             let (encoding, confidence, _) = chardet::detect(&bytes);
             // TODO: be able to adjust chardet confidence here
             if confidence > 0.80 {

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -20,7 +20,14 @@ pub fn get_encoder(bytes: &[u8], rg_encoding: &RgEncoding) -> (Option<Bom>, Enco
             let (encoding, confidence, _) = chardet::detect(&bytes);
             // TODO: be able to adjust chardet confidence here
             if confidence > 0.80 {
-                encoding_from_whatwg_label(charset2encoding(&encoding))
+                // If we pass "ascii" to `encoding_from_whatwg_label` then it will default to using the "windows-1252"
+                // encoding. However, this may be confusing as most users are more familiar with ASCII encodings and may
+                // be unaware that "windows-1252" is an ASCII compatible encoding.
+                if encoding == "ascii" {
+                    Some(encoding::all::ASCII)
+                } else {
+                    encoding_from_whatwg_label(charset2encoding(&encoding))
+                }
             } else {
                 None
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,7 +48,7 @@ fn main() {
                     }
 
                     match replace::perform_replacements(replacement_criteria) {
-                        Ok(results) => eprintln!("{}", results),
+                        Ok(_) => println!("Complete!"),
                         Err(err) => {
                             eprintln!("An error occurred during replacement: {}", err);
                             process::exit(1);

--- a/src/model/replacement.rs
+++ b/src/model/replacement.rs
@@ -1,7 +1,3 @@
-use std::collections::HashMap;
-use std::fmt::{self, Display, Formatter};
-use std::path::{Path, PathBuf};
-
 use crate::model::Item;
 
 #[derive(Debug)]
@@ -23,76 +19,5 @@ impl ReplacementCriteria {
 
     pub fn set_encoding(&mut self, encoding: impl AsRef<str>) {
         self.encoding = Some(encoding.as_ref().to_owned());
-    }
-}
-
-#[derive(Debug)]
-pub enum ReplacementAttempt {
-    Success(String),
-    Failure(String),
-}
-
-impl Display for ReplacementAttempt {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        match self {
-            ReplacementAttempt::Success(matched_text) => write!(f, "Replaced: {}", matched_text),
-            ReplacementAttempt::Failure(reason) => write!(f, "Error replacing match: {}", reason),
-        }
-    }
-}
-
-#[derive(Debug)]
-pub struct ReplacementResult {
-    pub text: String,
-    /// Map of (Path, DetectedEncoding) -> [List, Of, Matches, Replaced]
-    pub replacements: HashMap<(PathBuf, String), Vec<ReplacementAttempt>>,
-}
-
-impl ReplacementResult {
-    pub fn new(text: impl AsRef<str>) -> ReplacementResult {
-        let text = text.as_ref().to_owned();
-        ReplacementResult {
-            text,
-            replacements: HashMap::new(),
-        }
-    }
-
-    pub fn add_replacement<P, S>(
-        &mut self,
-        path: P,
-        mut matches: Vec<ReplacementAttempt>,
-        detected_encoding: S,
-    ) where
-        P: AsRef<Path>,
-        S: AsRef<str>,
-    {
-        let path = path.as_ref().to_owned();
-        let detected_encoding = detected_encoding.as_ref().to_owned();
-
-        self.replacements
-            .entry((path, detected_encoding))
-            .and_modify(|v| (*v).append(&mut matches))
-            .or_insert_with(|| matches);
-    }
-}
-
-impl Display for ReplacementResult {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        let mut total_replacements = 0;
-        for ((path, encoding), replacements) in &self.replacements {
-            if !replacements.is_empty() {
-                writeln!(f, "file: {} <{}>", path.display(), encoding)?;
-                for r in replacements {
-                    writeln!(f, "  {}", r)?;
-                    total_replacements += 1;
-                }
-            }
-        }
-
-        writeln!(f)?;
-        writeln!(f, "Replacement text: {}", self.text)?;
-        writeln!(f, "Total matches replaced: {}", total_replacements)?;
-
-        Ok(())
     }
 }

--- a/src/replace.rs
+++ b/src/replace.rs
@@ -6,12 +6,12 @@ use encoding::label::encoding_from_whatwg_label;
 use encoding::{DecoderTrap, EncoderTrap};
 
 use crate::encoding::{get_encoder, Bom};
-use crate::model::{ReplacementAttempt, ReplacementCriteria, ReplacementResult};
+use crate::model::ReplacementCriteria;
 use crate::rg::de::{RgMessageKind, SubMatch};
 use crate::rg::RgEncoding;
 
 // TODO: better error handling and messaging to the user when any of this fails
-pub fn perform_replacements(criteria: ReplacementCriteria) -> Result<ReplacementResult> {
+pub fn perform_replacements(criteria: ReplacementCriteria) -> Result<()> {
     // If we've been passed an encoding, then try to create an encoder from it.
     let rg_encoding = match criteria.encoding.as_ref() {
         Some(label) => {
@@ -25,7 +25,7 @@ pub fn perform_replacements(criteria: ReplacementCriteria) -> Result<Replacement
         None => RgEncoding::None,
     };
 
-    Ok(criteria
+    criteria
         .items
         .iter()
         // Iterate backwards so the offset doesn't change as we make replacements.
@@ -33,12 +33,11 @@ pub fn perform_replacements(criteria: ReplacementCriteria) -> Result<Replacement
         // The only item kind we replace is the Match kind.
         .filter(|item| matches!(item.kind, RgMessageKind::Match) && item.should_replace)
         // Perform the replacement on each match.
-        .fold(ReplacementResult::new(&criteria.text), |mut res, item| {
+        .for_each(|item| {
             let file_path = item.path().expect("match item did not have a path!");
 
             // Decode file.
             let (bom, encoder, mut file_as_str) = {
-                // TODO: don't read file completely into memory, but use a buffered approach instead
                 let mut file_contents = vec![];
                 OpenOptions::new()
                     .read(true)
@@ -67,62 +66,46 @@ pub fn perform_replacements(criteria: ReplacementCriteria) -> Result<Replacement
                 match encoder.decode(&file_contents, DecoderTrap::Strict) {
                     Ok(s) => (bom, encoder, s),
                     Err(e) => {
-                        res.add_replacement(
-                            &file_path,
-                            vec![ReplacementAttempt::Failure(format!(
-                                "Failed to decode file: {}",
-                                e
-                            ))],
-                            encoder.name(),
-                        );
-                        return res;
+                        eprintln!("Failed to decode file: {}", e);
+                        return;
                     }
                 }
             };
 
-            // Replace matches within the file contents with the given `replacement` string.
-            let replaced_matches = item.matches().map_or_else(
-                || vec![],
-                |submatches| {
-                    let offset = item.offset().unwrap();
+            println!("file: {} <{}>", file_path.display(), encoder.name());
 
-                    // Iterate backwards so the offset doesn't change as we make replacements.
-                    submatches
-                        .iter()
-                        .rev()
-                        .map(|SubMatch { text, range }| {
-                            let normalised_range = (offset + range.start)..(offset + range.end);
-                            dbg!(&normalised_range);
-                            let str_to_remove = &file_as_str[normalised_range.clone()];
-                            if str_to_remove.as_bytes() == text.to_vec().as_slice() {
-                                let removed_str = str_to_remove.to_string();
-                                file_as_str.replace_range(normalised_range, &criteria.text);
-                                ReplacementAttempt::Success(removed_str)
-                            } else {
-                                ReplacementAttempt::Failure(format!(
-                                    "Matched bytes do not match bytes to replace in {}@{}!",
-                                    file_path.display(),
-                                    offset + range.start,
-                                ))
-                            }
-                        })
-                        .collect()
-                },
-            );
+            // Replace matches within the file contents with the given `replacement` string.
+            item.matches().iter().for_each(|submatches| {
+                let offset = item.offset().unwrap();
+
+                // Iterate backwards so the offset doesn't change as we make replacements.
+                submatches
+                    .iter()
+                    .rev()
+                    .map(|SubMatch { text, range }| {
+                        let normalised_range = (offset + range.start)..(offset + range.end);
+                        let str_to_remove = &file_as_str[normalised_range.clone()];
+                        if str_to_remove.as_bytes() == text.to_vec().as_slice() {
+                            let removed_str = str_to_remove.to_string();
+                            file_as_str.replace_range(normalised_range, &criteria.text);
+                            println!("Replaced: {}", removed_str);
+                        } else {
+                            eprintln!(
+                                "Matched bytes do not match bytes to replace in {}@{}!",
+                                file_path.display(),
+                                offset + range.start,
+                            )
+                        }
+                    })
+                    .collect()
+            });
 
             // Convert back into the detected encoding.
             let replaced_contents = match encoder.encode(&file_as_str, EncoderTrap::Strict) {
                 Ok(bytes) => bytes,
                 Err(e) => {
-                    res.add_replacement(
-                        &file_path,
-                        vec![ReplacementAttempt::Failure(format!(
-                            "Failed to encode replaced string: {}",
-                            e
-                        ))],
-                        encoder.name(),
-                    );
-                    return res;
+                    eprintln!("Failed to encode replaced string: {}", e);
+                    return;
                 }
             };
 
@@ -155,12 +138,9 @@ pub fn perform_replacements(criteria: ReplacementCriteria) -> Result<Replacement
             // Overwrite the original file with the patched temp file.
             #[cfg(not(windows))]
             fs::rename(temp_file_path, &file_path).unwrap();
+        });
 
-            // Add the results of the replacement.
-            // TODO: potentially log these as they occur to avoid hanging on a lot of files.
-            res.add_replacement(&file_path, replaced_matches, encoder.name());
-            res
-        }))
+    Ok(())
 }
 
 #[cfg(test)]
@@ -225,8 +205,7 @@ mod tests {
             build_item(RgMessageKind::Summary, &f5),
         ];
 
-        let result = perform_replacements(ReplacementCriteria::new("NEW_VALUE", items)).unwrap();
-        assert_eq!(result.replacements.len(), 1);
+        perform_replacements(ReplacementCriteria::new("NEW_VALUE", items)).unwrap();
 
         assert_eq!(fs::read_to_string(f1.path()).unwrap(), text);
         assert_eq!(fs::read_to_string(f2.path()).unwrap(), text);

--- a/src/rg/exec.rs
+++ b/src/rg/exec.rs
@@ -1,16 +1,12 @@
 use std::collections::VecDeque;
 use std::ffi::OsStr;
 use std::fmt::Display;
-use std::io::ErrorKind;
-use std::process::Command;
+use std::io::{self, BufRead, BufReader, ErrorKind, Read, Write};
+use std::process::{Command, Stdio};
 
 use anyhow::{anyhow, Error, Result};
 
 use crate::rg::de::RgMessage;
-
-fn vec_to_string(v: Vec<u8>) -> String {
-    String::from_utf8(v).unwrap().trim().to_string()
-}
 
 fn rg_run_error(msg: impl Display) -> Error {
     anyhow!("An error occurred when running `rg`:\n\n{}", msg)
@@ -21,15 +17,16 @@ where
     I: IntoIterator<Item = S>,
     S: AsRef<OsStr>,
 {
-    let output = match Command::new("rg")
+    let mut child = match Command::new("rg")
         // We use the JSON output
         .arg("--json")
         // We don't (yet?) support reading `rg`'s config files
         .arg("--no-config")
         .args(args)
-        .output()
+        .stdout(Stdio::piped())
+        .spawn()
     {
-        Ok(output) => output,
+        Ok(child) => child,
         Err(e) => {
             if let ErrorKind::NotFound = e.kind() {
                 return Err(anyhow!(
@@ -41,21 +38,44 @@ where
         }
     };
 
-    if !output.status.success() {
-        if output.stderr.is_empty() {
-            return Err(anyhow!("No matches found"));
-        } else {
-            return Err(rg_run_error(vec_to_string(output.stderr)));
-        }
-    }
-
     let mut rg_messages: VecDeque<RgMessage> = VecDeque::new();
-    for line in vec_to_string(output.stdout).lines() {
+    let rg_stdout = BufReader::new(child.stdout.as_mut().unwrap());
+    for (i, line) in rg_stdout.lines().enumerate() {
+        // For large result lists show some progress in the terminal.
+        if i > 0 && i % 1000 == 0 {
+            let _ = io::stdout().write_all(format!("\rMatches found: ~{}", i).as_bytes());
+            let _ = io::stdout().flush();
+        }
+
         rg_messages.push_back(
-            serde_json::from_str(line)
-            .map_err(|e| anyhow!("Failed to read JSON output from `rg`: {}\nMost likely arguments that conflict with --json were passed to `rg`.", e))?
+            serde_json::from_str(&line?)
+                .map_err(|e| anyhow!("Failed to read JSON output from `rg`: {}", e))?,
         );
     }
 
-    Ok(rg_messages)
+    // Wait for ripgrep to finish before returning.
+    match child.wait() {
+        Ok(exit_status) if exit_status.success() => Ok(rg_messages),
+        Ok(_) => {
+            let mut rg_stderr = String::new();
+            Err(
+                match child
+                    .stderr
+                    .as_mut()
+                    .unwrap()
+                    .read_to_string(&mut rg_stderr)
+                {
+                    Ok(_) => {
+                        if rg_stderr.is_empty() {
+                            anyhow!("No matches found")
+                        } else {
+                            rg_run_error(rg_stderr)
+                        }
+                    }
+                    Err(e) => anyhow!("failed to read rg's stderr: {}", e),
+                },
+            )
+        }
+        Err(e) => Err(anyhow!("failed to wait for rg to end: {}", e)),
+    }
 }

--- a/src/rg/mod.rs
+++ b/src/rg/mod.rs
@@ -1,6 +1,9 @@
 pub mod de;
 pub mod exec;
 
+use std::convert::From;
+
+use encoding::label::encoding_from_whatwg_label;
 use encoding::EncodingRef;
 
 /// A small wrapper to help describe the encoding that we think ripgrep will use.
@@ -19,6 +22,25 @@ impl RgEncoding {
         match &self {
             RgEncoding::Some(enc) => Some(*enc),
             _ => None,
+        }
+    }
+}
+
+impl From<&str> for RgEncoding {
+    fn from(s: &str) -> Self {
+        if s == "none" {
+            RgEncoding::NoneExplicit
+        } else {
+            encoding_from_whatwg_label(s).map_or_else(|| RgEncoding::None, |e| RgEncoding::Some(e))
+        }
+    }
+}
+
+impl From<&Option<String>> for RgEncoding {
+    fn from(input: &Option<String>) -> Self {
+        match input {
+            Some(label) => Self::from(label.as_str()),
+            None => RgEncoding::None,
         }
     }
 }


### PR DESCRIPTION
* [x] stream output as it occurs, not at the end
* [x] read ripgreps output as it's sent via stdout, not just when the child exits
* [x] (fix) only open each separate file _once_ when performing replacements, not multiple times
