### PR TITLE
fix: increase timeouts for building

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,6 +154,7 @@ jobs:
 
     - name: Build release binary
       run: ${{ env.CARGO }} build --verbose --release ${{ env.TARGET_FLAGS }}
+      timeout-minutes: 10
 
     - name: Strip release binary (linux and macos)
       if: matrix.build == 'linux' || matrix.build == 'macos'


### PR DESCRIPTION
Seems that the macOS and Windows builds are failing, not sure why, but it could be due to timeouts.
See: https://github.com/actions/runner/issues/2323