### PR TITLE
Fix windows builds in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
           rust: nightly-x86_64-gnu
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: recursive
 
@@ -101,7 +101,7 @@ jobs:
         ci/install-packages-macos.sh
 
     - name: Install Rust
-      uses: actions-rs/toolchain@v1
+      uses: actions-rs/toolchain@v2
       with:
         toolchain: ${{ matrix.rust }}
         profile: minimal
@@ -167,9 +167,9 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Install Rust
-      uses: actions-rs/toolchain@v1
+      uses: actions-rs/toolchain@v2
       with:
         toolchain: stable
         override: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
         ci/install-packages-macos.sh
 
     - name: Install Rust
-      uses: actions-rs/toolchain@v2
+      uses: actions-rs/toolchain@v1
       with:
         toolchain: ${{ matrix.rust }}
         profile: minimal
@@ -169,7 +169,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
     - name: Install Rust
-      uses: actions-rs/toolchain@v2
+      uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
         override: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,7 +116,7 @@ jobs:
         ci/install-packages-macos.sh
 
     - name: Install Rust
-      uses: actions-rs/toolchain@v2
+      uses: actions-rs/toolchain@v1
       with:
         toolchain: ${{ matrix.rust }}
         profile: minimal
@@ -225,7 +225,7 @@ jobs:
         ci/install-packages-ubuntu.sh
 
     - name: Install Rust
-      uses: actions-rs/toolchain@v2
+      uses: actions-rs/toolchain@v1
       with:
         toolchain: nightly
         profile: minimal

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
   push:
     # Enable when testing release infrastructure on a branch.
     # branches:
-    # - release/xyz
+    # - test-release
     tags:
     - '[0-9]+.[0-9]+.[0-9]+'
 jobs:
@@ -100,7 +100,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 1
         submodules: recursive
@@ -116,7 +116,7 @@ jobs:
         ci/install-packages-macos.sh
 
     - name: Install Rust
-      uses: actions-rs/toolchain@v1
+      uses: actions-rs/toolchain@v2
       with:
         toolchain: ${{ matrix.rust }}
         profile: minimal
@@ -171,6 +171,7 @@ jobs:
 
     # FIXME: for some reasons the manpage isn't generated in CI from the build.rs script.
     # So we build it (again?) here too.
+    # NOTE: the windows builds don't create a target-triple directory under "target/"
     - name: Build archive
       shell: bash
       run: |
@@ -185,7 +186,7 @@ jobs:
         cp "$outdir"/{_rgr,rgr.bash,rgr.fish,_rgr.ps1} "$staging/complete/"
 
         if [ "${{ matrix.os }}" = "windows-2019" ]; then
-          cp "target/${{ matrix.target }}/release/rgr.exe" "$staging/"
+          cp "target/release/rgr.exe" "$staging/"
           7z a "$staging.zip" "$staging"
           echo "ASSET=$staging.zip" >> $GITHUB_ENV
         else
@@ -224,7 +225,7 @@ jobs:
         ci/install-packages-ubuntu.sh
 
     - name: Install Rust
-      uses: actions-rs/toolchain@v1
+      uses: actions-rs/toolchain@v2
       with:
         toolchain: nightly
         profile: minimal

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -751,7 +751,7 @@ checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "repgrep"
-version = "0.10.6"
+version = "0.10.7"
 dependencies = [
  "anyhow",
  "base64-simd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "repgrep"
-version = "0.10.6"
+version = "0.10.7"
 description = "An interactive command line replacer for `ripgrep`."
 homepage = "https://github.com/acheronfail/repgrep"
 repository = "https://github.com/acheronfail/repgrep"


### PR DESCRIPTION
This _should_ fix #61.

Seems that in CI the windows builds don't nest the output under `target/TRIPLE/release/`, but rather just `target/release/`, not sure why... :thinking: 

Either way, this should hopefully fix it.