### PR TITLE
Various performance improvements

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,7 @@ jobs:
         with:
           tag_name: ${{ env.CRATE_VERSION }}
           release_name: ${{ env.CRATE_VERSION }}
+          draft: true
 
       - name: Save release upload URL to artifact
         run: echo "${{ steps.release.outputs.upload_url }}" > artifacts/release-upload-url

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -751,7 +751,7 @@ checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "repgrep"
-version = "0.10.7"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "base64-simd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "repgrep"
-version = "0.10.7"
+version = "0.11.0"
 description = "An interactive command line replacer for `ripgrep`."
 homepage = "https://github.com/acheronfail/repgrep"
 repository = "https://github.com/acheronfail/repgrep"

--- a/DEVELOPMENT_NOTES.md
+++ b/DEVELOPMENT_NOTES.md
@@ -1,0 +1,17 @@
+# Development Notes
+
+When running with `debug_assertions` enabled `rgr` will write its log file to `rgr.log` in the current working directory.
+
+Thus, it's fairly straightforward to use a development flow with two terminals:
+
+```bash
+# Terminal 1
+# This follows and displays `rgr`'s logs
+tail -f ./rgr.log
+```
+
+```bash
+# Terminal 2
+# This builds and runs `rgr` in debug mode with logging enabled
+RUST_LOG=trace cargo run -- <rg args>
+```

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,7 +87,14 @@ use crate::rg::read::read_messages;
 
 fn init_logging() -> Result<::std::path::PathBuf> {
     let log_dir = env::temp_dir().join(format!(".{}", crate_name!()));
-    let log_spec = FileSpec::default().directory(&log_dir);
+    let log_spec = if cfg!(debug_assertions) {
+        FileSpec::default()
+            .directory(env::current_dir().unwrap())
+            .basename("rgr")
+            .use_timestamp(false)
+    } else {
+        FileSpec::default().directory(&log_dir)
+    };
     Logger::try_with_env()
         .expect("Please pass a valid RUST_LOG string, see: https://docs.rs/flexi_logger/latest/flexi_logger/struct.LogSpecification.html")
         .log_to_file(log_spec)

--- a/src/model/printable.rs
+++ b/src/model/printable.rs
@@ -71,71 +71,86 @@ pub trait Printable {
 impl Printable for &str {
     fn to_printable(&self, style: PrintableStyle) -> String {
         match style {
-            PrintableStyle::Hidden => self
-                // Print common control characters as a single space
-                .replace(&['\x09', '\x0D'][..], " ")
-                // Strip all other control characters to hide them
-                .replace(
-                    &[
-                        '\x00', '\x01', '\x02', '\x03', '\x04', '\x05', '\x06', '\x07', '\x08',
-                        '\x0B', '\x0C', '\x0E', '\x0F', '\x10', '\x11', '\x12', '\x13', '\x14',
-                        '\x15', '\x16', '\x17', '\x18', '\x19', '\x1A', '\x1B', '\x1C', '\x1D',
-                        '\x1E', '\x1F', '\x7F',
-                    ][..],
-                    "",
-                ),
+            PrintableStyle::Hidden => {
+                let mut s = String::with_capacity(self.len());
+                for ch in self.chars() {
+                    match ch {
+                        '\x00' | '\x01' | '\x02' | '\x03' | '\x04' | '\x05' | '\x06' | '\x07'
+                        | '\x08' | '\x0B' | '\x0C' | '\x0E' | '\x0F' | '\x10' | '\x11' | '\x12'
+                        | '\x13' | '\x14' | '\x15' | '\x16' | '\x17' | '\x18' | '\x19' | '\x1A'
+                        | '\x1B' | '\x1C' | '\x1D' | '\x1E' | '\x1F' | '\x7F' => {}
+                        '\x09' | '\x0D' => s.push(' '),
+                        _ => s.push(ch),
+                    }
+                }
 
-            PrintableStyle::Common(oneline) => self
-                // Print common whitespace as symbols
-                .replace('\x09', "→") // HT (Horizontal Tab)
-                .replace('\x0A', if oneline { "¬" } else { "¬\n" }) // LF (Line feed)
-                .replace('\x0D', "¤") // CR (Carriage return)
-                .replace('\x20', "␣") // SP (Space)
-                // Print other control characters with a replacement
-                .replace(
-                    &[
-                        '\x00', '\x01', '\x02', '\x03', '\x04', '\x05', '\x06', '\x07', '\x08',
-                        '\x0B', '\x0C', '\x0E', '\x0F', '\x10', '\x11', '\x12', '\x13', '\x14',
-                        '\x15', '\x16', '\x17', '\x18', '\x19', '\x1A', '\x1B', '\x1C', '\x1D',
-                        '\x1E', '\x1F', '\x7F',
-                    ][..],
-                    "•",
-                ),
-            PrintableStyle::All(oneline) => self
-                .replace('\x00', "␀") // NULL (Null character)
-                .replace('\x01', "␁") // SOH (Start of Header)
-                .replace('\x02', "␂") // STX (Start of Text)
-                .replace('\x03', "␃") // ETX (End of Text)
-                .replace('\x04', "␄") // EOT (End of Trans.)
-                .replace('\x05', "␅") // ENQ (Enquiry)
-                .replace('\x06', "␆") // ACK (Acknowledgement)
-                .replace('\x07', "␇") // BEL (Bell)
-                .replace('\x08', "␈") // BS (Backspace)
-                .replace('\x09', "␉") // HT (Horizontal Tab)
-                .replace('\x0A', if oneline { "␊" } else { "␊\n" }) // LF (Line feed)
-                .replace('\x0B', "␋") // VT (Vertical Tab)
-                .replace('\x0C', "␌") // FF (Form feed)
-                .replace('\x0D', "␍") // CR (Carriage return)
-                .replace('\x0E', "␎") // SO (Shift Out)
-                .replace('\x0F', "␏") // SI (Shift In)
-                .replace('\x10', "␐") // DLE (Data link escape)
-                .replace('\x11', "␑") // DC1 (Device control 1)
-                .replace('\x12', "␒") // DC2 (Device control 2)
-                .replace('\x13', "␓") // DC3 (Device control 3)
-                .replace('\x14', "␔") // DC4 (Device control 4)
-                .replace('\x15', "␕") // NAK (Negative acknowl.)
-                .replace('\x16', "␖") // SYN (Synchronous idle)
-                .replace('\x17', "␗") // ETB (End of trans. block)
-                .replace('\x18', "␘") // CAN (Cancel)
-                .replace('\x19', "␙") // EM (End of medium)
-                .replace('\x1A', "␚") // SUB (Substitute)
-                .replace('\x1B', "␛") // ESC (Escape)
-                .replace('\x1C', "␜") // FS (File separator)
-                .replace('\x1D', "␝") // GS (Group separator)
-                .replace('\x1E', "␞") // RS (Record separator)
-                .replace('\x1F', "␟") // US (Unit separator)
-                .replace('\x20', "␠") // SP (Space)
-                .replace('\x7F', "␡"), // DEL (Delete)
+                s
+            }
+
+            PrintableStyle::Common(oneline) => {
+                let mut s = String::with_capacity(self.len());
+                for ch in self.chars() {
+                    match ch {
+                        // Print common whitespace as symbols
+                        '\x09' => s.push('→'), // HT (Horizontal Tab)
+                        '\x0A' => s.push_str(if oneline { "¬" } else { "¬\n" }), // LF (Line feed)
+                        '\x0D' => s.push('¤'),  // CR (Carriage return)
+                        '\x20' => s.push('␣'), // SP (Space)
+                        // Print other control characters with a replacement
+                        '\x00' | '\x01' | '\x02' | '\x03' | '\x04' | '\x05' | '\x06' | '\x07'
+                        | '\x08' | '\x0B' | '\x0C' | '\x0E' | '\x0F' | '\x10' | '\x11' | '\x12'
+                        | '\x13' | '\x14' | '\x15' | '\x16' | '\x17' | '\x18' | '\x19' | '\x1A'
+                        | '\x1B' | '\x1C' | '\x1D' | '\x1E' | '\x1F' | '\x7F' => s.push('•'),
+                        c => s.push(c),
+                    }
+                }
+
+                s
+            }
+            PrintableStyle::All(oneline) => {
+                let mut s = String::with_capacity(self.len());
+                for ch in self.chars() {
+                    match ch {
+                        '\x00' => s.push('␀'), // NULL (Null character)
+                        '\x01' => s.push('␁'), // SOH (Start of Header)
+                        '\x02' => s.push('␂'), // STX (Start of Text)
+                        '\x03' => s.push('␃'), // ETX (End of Text)
+                        '\x04' => s.push('␄'), // EOT (End of Trans.)
+                        '\x05' => s.push('␅'), // ENQ (Enquiry)
+                        '\x06' => s.push('␆'), // ACK (Acknowledgement)
+                        '\x07' => s.push('␇'), // BEL (Bell)
+                        '\x08' => s.push('␈'), // BS (Backspace)
+                        '\x09' => s.push('␉'), // HT (Horizontal Tab)
+                        '\x0A' => s.push_str(if oneline { "␊" } else { "␊\n" }), // LF (Line feed)
+                        '\x0B' => s.push('␋'), // VT (Vertical Tab)
+                        '\x0C' => s.push('␌'), // FF (Form feed)
+                        '\x0D' => s.push('␍'), // CR (Carriage return)
+                        '\x0E' => s.push('␎'), // SO (Shift Out)
+                        '\x0F' => s.push('␏'), // SI (Shift In)
+                        '\x10' => s.push('␐'), // DLE (Data link escape)
+                        '\x11' => s.push('␑'), // DC1 (Device control 1)
+                        '\x12' => s.push('␒'), // DC2 (Device control 2)
+                        '\x13' => s.push('␓'), // DC3 (Device control 3)
+                        '\x14' => s.push('␔'), // DC4 (Device control 4)
+                        '\x15' => s.push('␕'), // NAK (Negative acknowl.)
+                        '\x16' => s.push('␖'), // SYN (Synchronous idle)
+                        '\x17' => s.push('␗'), // ETB (End of trans. block)
+                        '\x18' => s.push('␘'), // CAN (Cancel)
+                        '\x19' => s.push('␙'), // EM (End of medium)
+                        '\x1A' => s.push('␚'), // SUB (Substitute)
+                        '\x1B' => s.push('␛'), // ESC (Escape)
+                        '\x1C' => s.push('␜'), // FS (File separator)
+                        '\x1D' => s.push('␝'), // GS (Group separator)
+                        '\x1E' => s.push('␞'), // RS (Record separator)
+                        '\x1F' => s.push('␟'), // US (Unit separator)
+                        '\x20' => s.push('␠'), // SP (Space)
+                        '\x7F' => s.push('␡'), // DEL (Delete)
+                        c => s.push(c),
+                    }
+                }
+
+                s
+            }
         }
     }
 }

--- a/src/ui/app/app_render.rs
+++ b/src/ui/app/app_render.rs
@@ -246,6 +246,7 @@ impl App {
 
     fn draw_main_view<B: Backend>(&mut self, f: &mut Frame<B>, r: Rect) {
         let list_rect = self.main_view_list_rect(f.size());
+        let indicator_symbol = self.list_indicator();
 
         // For performance with large match sets, we only send a single "window"'s
         // worth of lines to the terminal. For all our calculations, we use a line
@@ -255,6 +256,7 @@ impl App {
         let window_height = list_rect.height as usize;
         let window_start = self.list_state.window_start();
         let window_end = window_start + window_height;
+
         let ctx = &UiItemContext {
             replacement_text: self.ui_state.get_replacement_text(),
             printable_style: self.printable_style,
@@ -263,25 +265,42 @@ impl App {
             list_rect,
         };
 
-        // TODO: make this prettier
-        // FIXME: cache `item.line_count`
-
-        let mut height = 0;
+        // iterate over all our items and collect only those that will be in the visible
+        // window region of the list (skipping all the others)
         let mut match_items = vec![];
-        // FIXME: why does this iter_mut prevent immutable references after - I think it's because `line` contains COWs?
-        for item in self.list.iter() {
-            let line_height = item.line_count(list_rect.width, self.printable_style);
-            if height >= window_start && height < window_end {
+        let mut curr_height = 0;
+        for item in self.list.iter_mut() {
+            // we've passed the visible region
+            if curr_height > window_end {
+                break;
+            }
+
+            let line_count = item.line_count(list_rect.width, self.printable_style);
+
+            // items that fall in the visible window, but don't start in the visible window
+            if curr_height < window_start {
+                let gap = (curr_height + line_count).saturating_sub(window_start);
+                if gap > 0 {
+                    let lines = item.to_span_lines(ctx);
+                    let padding = lines.len() - gap;
+                    for line in lines.into_iter().skip(padding) {
+                        match_items.push(ListItem::new(line));
+                    }
+                }
+            }
+
+            // items that start in the visible window
+            if curr_height >= window_start {
                 for line in item.to_span_lines(ctx).into_iter() {
                     match_items.push(ListItem::new(line));
                 }
             }
-            height += line_height;
+
+            curr_height += line_count;
         }
 
         // TODO: highlight the bg of whole line (not just the text on it), currently not possible
         // See: https://github.com/fdehau/tui-rs/issues/239#issuecomment-657070300
-        let indicator_symbol = self.list_indicator();
         let match_list = List::new(match_items)
             .block(Block::default())
             .style(Style::default().fg(Color::White))

--- a/src/ui/app/state.rs
+++ b/src/ui/app/state.rs
@@ -12,6 +12,10 @@ pub struct AppListState {
     selected_submatch: usize,
     /// The position of the indicator on the left of the main list view
     indicator: ListState,
+    /// The position of the start of the visible window in the main list view.
+    /// We only send the visible lines to the renderer for performance reasons, and
+    /// this represents the beginning of the visible window.
+    window_start: usize,
 }
 
 impl AppListState {
@@ -22,6 +26,7 @@ impl AppListState {
             selected_item: 0,
             selected_submatch: 0,
             indicator: list_state,
+            window_start: 0,
         }
     }
 
@@ -31,6 +36,14 @@ impl AppListState {
 
     pub fn set_indicator_pos(&mut self, idx: usize) {
         self.indicator.select(Some(idx));
+    }
+
+    pub fn window_start(&self) -> usize {
+        self.window_start
+    }
+
+    pub fn set_window_start(&mut self, start: usize) {
+        self.window_start = start;
     }
 
     pub fn selected_item(&self) -> usize {
@@ -76,6 +89,14 @@ impl AppUiState {
             self,
             AppUiState::InputReplacement(_) | AppUiState::ConfirmReplacement(_)
         )
+    }
+
+    pub fn get_replacement_text(&self) -> Option<&str> {
+        match &self {
+            AppUiState::InputReplacement(replacement)
+            | AppUiState::ConfirmReplacement(replacement) => Some(replacement.as_str()),
+            _ => None,
+        }
     }
 
     /// Represent the `AppUiState` as a `Text`.

--- a/src/ui/line/item.rs
+++ b/src/ui/line/item.rs
@@ -29,6 +29,8 @@ pub struct Item {
     cached_line_count: Option<CachedLineCount>,
 }
 
+// This is implemented manually, so the `cached_line_count` field isn't used in
+// equality checks. All other fields should be included.
 impl PartialEq for Item {
     fn eq(&self, other: &Self) -> bool {
         self.index == other.index

--- a/src/ui/tui.rs
+++ b/src/ui/tui.rs
@@ -54,7 +54,7 @@ impl Tui {
             // If drawing to the terminal is slow, flush all keyboard events so they're not buffered.
             // (Otherwise with very slow updates, the user has to wait for all keyboard events to be processed
             // before being able to quit the app, etc).
-            if before_draw.elapsed() > Duration::from_millis(200) {
+            if before_draw.elapsed() > Duration::from_millis(20) {
                 while let Ok(_) = rx.try_recv() {}
             }
 

--- a/src/ui/tui.rs
+++ b/src/ui/tui.rs
@@ -48,7 +48,6 @@ impl Tui {
 
         loop {
             let before_draw = Instant::now();
-            let term_size = term.get_frame().size();
             term.draw(|mut f| self.app.draw(&mut f))?;
 
             // If drawing to the terminal is slow, flush all keyboard events so they're not buffered.
@@ -59,6 +58,7 @@ impl Tui {
             }
 
             let event = rx.recv()?;
+            let term_size = term.get_frame().size();
             self.app.on_event(term_size, event)?;
 
             match self.app.state {


### PR DESCRIPTION
This change includes some performance improvements. Here they are (roughly in order of their impact):

1. keep track of a visible window and only render visible lines (skip all others)
2. only iterate the string a single time when calling `.to_printable`
3. memoise `Item::line_count` for a given width, so it's not re-calculated unless the terminal width changes

This also includes some other quality of life changes, as well as decreasing the input flush threshold from 200ms to 20ms.

Fixes #66 