### PR TITLE
fix: create temp files next to original files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.12.1
+
+- fae1d38 fix: create temp files next to original files
+- af37ebb Merge pull request #77 from acheronfail/feat/ability-to-invert-selection
+
 # 0.12.0
 
 Added a new feature: the ability to "invert" selections:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -751,7 +751,7 @@ checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "repgrep"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "base64-simd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "repgrep"
-version = "0.12.0"
+version = "0.12.1"
 description = "An interactive command line replacer for `ripgrep`."
 homepage = "https://github.com/acheronfail/repgrep"
 repository = "https://github.com/acheronfail/repgrep"

--- a/src/replace.rs
+++ b/src/replace.rs
@@ -1,7 +1,7 @@
 use std::fs::OpenOptions;
 use std::io::{Read, Write};
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use encoding::{DecoderTrap, EncoderTrap};
 use tempfile::NamedTempFile;
 
@@ -109,7 +109,13 @@ fn perform_replacements_in_file(
         .map_err(|e| anyhow!("Failed to encode replaced string: {}", e))?;
 
     // Create a temporary file.
-    let mut temp_file = NamedTempFile::new()?;
+    let parent_dir = path_buf.parent().with_context(|| {
+        anyhow!(
+            "Failed to get parent directory for file: {}",
+            path_buf.display()
+        )
+    })?;
+    let mut temp_file = NamedTempFile::new_in(parent_dir)?;
     let temp_file_path = temp_file.path().display().to_string();
     log::debug!("Creating temporary file: {}", temp_file_path);
 


### PR DESCRIPTION
Due to a [quirk](https://docs.rs/tempfile/3.4.0/tempfile/struct.NamedTempFile.html#method.persist) in the `tempfile` crate temporary files can't be persisted across filesystems. This change fixes the issue by creating the temporary file next to the original file.

I'm not sure if there's an easy way to create a unit test for this, which isn't the nicest. But hey, it'll do for now.

Fixes #65