### PR TITLE
fix: only mention log dir if logs are enabled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -751,7 +751,7 @@ checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "repgrep"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "anyhow",
  "base64-simd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "repgrep"
-version = "0.12.1"
+version = "0.12.2"
 description = "An interactive command line replacer for `ripgrep`."
 homepage = "https://github.com/acheronfail/repgrep"
 repository = "https://github.com/acheronfail/repgrep"

--- a/src/main.rs
+++ b/src/main.rs
@@ -119,7 +119,9 @@ fn main() {
         ($( $eprintln_arg:expr ),*) => {
             log::error!($( $eprintln_arg ),*);
             eprintln!($( $eprintln_arg ),*);
-            eprintln!("Logs available at: {}", log_dir.display());
+            if log::log_enabled!(log::Level::Error) {
+                eprintln!("Logs available at: {}", log_dir.display());
+            }
             process::exit(1);
         };
     }


### PR DESCRIPTION
Running

```bash
rgr <a_regex_that_matches_no_files>
```

will return

```txt
No matches returned from rg!
Logs available at: /tmp/.repgrep
```

even if logging isn't enabled.

This makes the `Logs available at...` message only appear if logs are enabled.