### PR TITLE
docs: update README.md about official Arch Linux package

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,17 +58,15 @@ See the [releases] page for pre-compiled binaries.
 cargo install repgrep
 ```
 
-#### From the AUR (Arch Linux)
+#### Via Pacman (Arch Linux)
 
 Maintained by [orhun](https://github.com/orhun).
 
-[`repgrep`](https://aur.archlinux.org/packages?O=0&K=repgrep) can be installed
-from the AUR using an [AUR helper](https://wiki.archlinux.org/title/AUR_helpers).
-
-For example:
+[`repgrep`](https://archlinux.org/packages/extra/x86_64/repgrep/) can be installed
+from the official repositories using [Pacman](https://wiki.archlinux.org/title/Pacman).
 
 ```bash
-paru -S repgrep
+pacman -S repgrep
 ```
 
 #### From Source (via Cargo)

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,17 +51,15 @@
 //! cargo install repgrep
 //! ```
 //!
-//! ### From the AUR (Arch Linux)
+//! #### Via Pacman (Arch Linux)
 //!
 //! Maintained by [orhun](https://github.com/orhun).
 //!
-//! [`repgrep`](https://aur.archlinux.org/packages?O=0&K=repgrep) can be installed
-//! from the AUR using an [AUR helper](https://wiki.archlinux.org/title/AUR_helpers).
-//!
-//! For example:
+//! [`repgrep`](https://archlinux.org/packages/extra/x86_64/repgrep/) can be installed
+//! from the official repositories using [Pacman](https://wiki.archlinux.org/title/Pacman).
 //!
 //! ```bash
-//! paru -S repgrep
+//! pacman -S repgrep
 //! ```
 //!
 //! ### From Source (via Cargo)

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,7 +51,7 @@
 //! cargo install repgrep
 //! ```
 //!
-//! #### Via Pacman (Arch Linux)
+//! ### Via Pacman (Arch Linux)
 //!
 //! Maintained by [orhun](https://github.com/orhun).
 //!


### PR DESCRIPTION
I have been using `rgr` for a while and I love it!

That's why I decided to move it to the official repositories: https://archlinux.org/packages/extra/x86_64/repgrep/

This PR simply updates the documentation about this change.
