### PR TITLE
0.14.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,7 +188,7 @@ jobs:
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: nightly
         override: true
         profile: minimal
         components: rustfmt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,4 +198,6 @@ jobs:
         cargo install just
         just setup
         just readme
+        rustup install nightly
+        just fmt
         just check-dirty

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 0.14.0
+
+- fae18c7 a little bling for the README
+- fae1a46 add documentation about capturing groups
+- fae1d7c snapshot tests for item rendering
+- fae1aed improve edge case of ascii encoding detection
+- fae1591 unit tests for replacements with capturing groups
+- fae1018 feat: add ability to user capturing groups in replacements
+- fae1488 dev: update justfile with default rule
+- fae1e2a update DEVELOPMENT_NOTES.md
+
 # 0.13.0
 
 - fae14d5 remove tag from just bump: we'll do it manually from now on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.14.0
+# 0.14.0 & 0.14.1
 
 - fae18c7 a little bling for the README
 - fae1a46 add documentation about capturing groups

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.20"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
 dependencies = [
  "memchr",
 ]
@@ -1028,9 +1028,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.1"
+version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
+checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1039,9 +1039,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.28"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
+checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
 name = "repgrep"
@@ -1066,6 +1066,7 @@ dependencies = [
  "num_cpus",
  "pretty_assertions",
  "rayon",
+ "regex",
  "safe-transmute",
  "serde",
  "serde_derive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1051,7 +1051,7 @@ checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
 name = "repgrep"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "base64-simd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -914,6 +914,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
+
+[[package]]
 name = "plotters"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1064,6 +1070,7 @@ dependencies = [
  "log",
  "memmap",
  "num_cpus",
+ "paste",
  "pretty_assertions",
  "rayon",
  "regex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1051,7 +1051,7 @@ checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
 name = "repgrep"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "base64-simd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ hex = "0.4.2"
 insta = "1.28.0"
 memmap = "0.7.0"
 num_cpus = "1.15.0"
+paste = "1.0.12"
 pretty_assertions = "1.3.0"
 rayon = "1.7.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ either = "1.6.1"
 encoding = "0.2.33"
 flexi_logger = "0.25.3"
 log = "0.4.11"
+regex = "1.8.4"
 safe-transmute = "0.11.0"
 serde = { version = "1.0.118", features = ["derive"] }
 serde_derive = "1.0.118"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "repgrep"
-version = "0.13.0"
+version = "0.14.0"
 description = "An interactive command line replacer for `ripgrep`."
 homepage = "https://github.com/acheronfail/repgrep"
 repository = "https://github.com/acheronfail/repgrep"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "repgrep"
-version = "0.14.0"
+version = "0.14.1"
 description = "An interactive command line replacer for `ripgrep`."
 homepage = "https://github.com/acheronfail/repgrep"
 repository = "https://github.com/acheronfail/repgrep"

--- a/DEVELOPMENT_NOTES.md
+++ b/DEVELOPMENT_NOTES.md
@@ -27,3 +27,13 @@ just dev <rg args>
 The README in this repository is generated from the doc comments in `src/main.rs`.
 
 Once the doc comments have been updated, run `just readme` to apply the changes to the README.
+
+## Making a release
+
+Mostly so I don't forget if I come back to this project after a while.
+
+1. use `just bump` to bump the version
+2. create PR with version bump and merge
+3. if merge commit has a successful CI build, then `git tag <version>` on `master`
+4. CI will create a draft release and start uploading artifacts to it
+5. edit it, and publish it as a release

--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ This is an interactive command line tool to make find and replacement easy.
 It uses [`ripgrep`] to find, and then provides you with a simple interface to see
 the replacements in real-time and conditionally replace matches.
 
+Some features:
+
+* ⚡ Super fast search results
+* ✨ Interactive interface for selecting which matches should be replaced or not
+* 🕶️ Live preview of the replacements
+* 🧠 Replace using capturing groups (e.g., when using `/foo (\w+)/` replace with `bar $1`)
+* 🦀 and more!
+
 Supported file encodings:
 
 * ASCII

--- a/benches/parsing_json.rs
+++ b/benches/parsing_json.rs
@@ -1,12 +1,10 @@
 #![allow(unused)]
 
-use std::{
-    fs::File,
-    io::{BufRead, BufReader, Read},
-    sync::Arc,
-    thread,
-    time::Duration,
-};
+use std::fs::File;
+use std::io::{BufRead, BufReader, Read};
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use crossbeam_queue::ArrayQueue;

--- a/build.rs
+++ b/build.rs
@@ -1,10 +1,9 @@
-use clap::CommandFactory;
-use clap_complete::{generate_to, shells};
-use std::env;
-use std::fs;
-use std::io;
 use std::path::Path;
 use std::process::Command;
+use std::{env, fs, io};
+
+use clap::CommandFactory;
+use clap_complete::{generate_to, shells};
 
 #[allow(dead_code)]
 #[path = "src/cli/args.rs"]

--- a/doc/rgr.1.template
+++ b/doc/rgr.1.template
@@ -21,6 +21,14 @@ The JSON output is then parsed, and you are presented with a terminal interface 
 Note since we use the *--json* flag, a number of *rg*'s flags are unavailable.
 See *rgr --help* for a list of supported flags that will be sent through to *ripgrep*.
 
+**Capturing Groups**
+
+You may use capturing groups when using *rgr*, for example *rgr "foo (\w+)"*.
+When using these, the matches can be used when replacing by referring to them as either their name *$name* or index *$1*.
+This syntax is inherited from the regex crate, see: https://docs.rs/regex/1.8.4/regex/struct.Captures.html#method.expand
+
+Only one pattern may be passed at a time when capturing groups are used (i.e., multiple *-e <pat>* flags are not allowed).
+
 **Reading results from a file**
 
 This tool also supports reading results from a JSON file, with the following use case in mind:

--- a/justfile
+++ b/justfile
@@ -4,6 +4,9 @@ badge-crates := "[![crate](https://img.shields.io/crates/v/repgrep)](https://cra
 badge-docs := "[![documentation](https://docs.rs/repgrep/badge.svg)](https://docs.rs/repgrep)"
 bench-json := "benches/rg.json"
 
+_default:
+    just -l
+
 # run this once after you pull down the repository
 setup:
     cargo install cargo-bump

--- a/justfile
+++ b/justfile
@@ -15,6 +15,10 @@ setup:
     if   command -v apt-get >/dev/null 2>&1 /dev/null; then sudo apt-get install ripgrep; fi
     if ! command -v rg      >/dev/null 2>&1 /dev/null; then echo "please install rg!"; exit 1; fi
 
+# tests rgr
+test:
+    cargo test --all --all-features
+
 # run rgr locally with logging enabled - use `just devlogs` to view output
 dev *args:
     RUST_LOG=trace cargo run -- "$@"

--- a/justfile
+++ b/justfile
@@ -16,8 +16,8 @@ setup:
     if ! command -v rg      >/dev/null 2>&1 /dev/null; then echo "please install rg!"; exit 1; fi
 
 # tests rgr
-test:
-    cargo test --all --all-features
+test *args:
+    RUST_LOG=trace cargo test --all --all-features "$@"
 
 # run rgr locally with logging enabled - use `just devlogs` to view output
 dev *args:

--- a/justfile
+++ b/justfile
@@ -15,6 +15,10 @@ setup:
     if   command -v apt-get >/dev/null 2>&1 /dev/null; then sudo apt-get install ripgrep; fi
     if ! command -v rg      >/dev/null 2>&1 /dev/null; then echo "please install rg!"; exit 1; fi
 
+# runs rustfmt
+fmt:
+    rustup run nightly cargo fmt
+
 # tests rgr
 test *args:
     RUST_LOG=trace cargo test --all --all-features "$@"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,3 @@
+imports_layout = "HorizontalVertical"
+imports_granularity = "Module"
+group_imports = "StdExternalCrate"

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -9,8 +9,7 @@ use std::env;
 use std::ffi::OsString;
 use std::path::PathBuf;
 
-use clap::{crate_authors, crate_version};
-use clap::{ArgAction, Parser};
+use clap::{crate_authors, crate_version, ArgAction, Parser};
 
 // TODO: options to support in the future
 // -P/--pcre2

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -42,6 +42,17 @@ pub fn parse_arguments() -> Result<Args> {
     validate_arguments(Args::parse())
 }
 
+impl Args {
+    /// Returns the patterns used by `rg` in the search.
+    pub fn rg_patterns(&self) -> Vec<&str> {
+        if let Some(pattern) = &self.pattern {
+            vec![pattern]
+        } else {
+            self.patterns.iter().map(|p| p.as_ref()).collect()
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::ffi::OsString;
@@ -60,15 +71,6 @@ mod tests {
         T: Into<OsString> + Clone,
     {
         validate_arguments(Args::parse_from(itr))
-    }
-
-    /// Returns the patterns used by `rg` in the search.
-    fn rg_patterns(args: &Args) -> Vec<&str> {
-        if let Some(pattern) = &args.pattern {
-            vec![pattern]
-        } else {
-            args.patterns.iter().map(|p| p.as_ref()).collect()
-        }
     }
 
     #[test]
@@ -101,7 +103,7 @@ mod tests {
     }
 
     #[test]
-    fn returns_rg_patterns() {
+    fn returns_rg_patterns_flags() {
         let args = parse_arguments_from(&[
             "rgr",
             "-e",
@@ -113,8 +115,14 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            rg_patterns(&args),
+            args.rg_patterns(),
             vec!["pattern-flag", "pattern-flag-long"]
         );
+    }
+
+    #[test]
+    fn returns_rg_patterns_positional() {
+        let args = parse_arguments_from(&["rgr", "positional"]).unwrap();
+        assert_eq!(args.rg_patterns(), vec!["positional"]);
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -4,9 +4,8 @@ use std::env;
 use std::path::PathBuf;
 
 use anyhow::{anyhow, Result};
-use clap::{CommandFactory, Parser};
-
 use args::Args;
+use clap::{CommandFactory, Parser};
 
 pub const ENV_JSON_FILE: &str = "RGR_JSON_FILE";
 

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -34,7 +34,7 @@ pub fn get_encoder(bytes: &[u8], rg_encoding: &RgEncoding) -> (Option<Bom>, Enco
         .or_else(|| {
             let (encoding, confidence, _) = chardet::detect(bytes);
             log::debug!(
-                "Attempting to detect encoding - cncoding: {}, Confidence: {}",
+                "Attempting to detect encoding - encoding: {}, Confidence: {}",
                 encoding,
                 confidence
             );
@@ -45,7 +45,11 @@ pub fn get_encoder(bytes: &[u8], rg_encoding: &RgEncoding) -> (Option<Bom>, Enco
                 // encoding. However, this may be confusing as most users are more familiar with ASCII encodings and may
                 // be unaware that "windows-1252" is an ASCII compatible encoding.
                 if encoding == "ascii" {
-                    Some(encoding::all::ASCII)
+                    // And, instead of forcing ASCII encoding here, we default to UTF8 which is far more common and
+                    // is also backwards compatible with ASCII. This allows multi-code-point graphemes to work, as well
+                    // as emoji and such.
+                    log::debug!("Detected ASCII encoding, defaulting to UTF8");
+                    Some(encoding::all::UTF_8)
                 } else {
                     encoding_from_whatwg_label(charset2encoding(&encoding))
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,14 @@
 //! It uses [`ripgrep`] to find, and then provides you with a simple interface to see
 //! the replacements in real-time and conditionally replace matches.
 //!
+//! Some features:
+//!
+//! * ⚡ Super fast search results
+//! * ✨ Interactive interface for selecting which matches should be replaced or not
+//! * 🕶️ Live preview of the replacements
+//! * 🧠 Replace using capturing groups (e.g., when using `/foo (\w+)/` replace with `bar $1`)
+//! * 🦀 and more!
+//!
 //! Supported file encodings:
 //!
 //! * ASCII

--- a/src/main.rs
+++ b/src/main.rs
@@ -180,7 +180,8 @@ fn main() {
                 .collect::<Vec<_>>()
                 .join(" ");
 
-            let result = Tui::new(rg_cmdline, rg_messages).start();
+            let patterns = args.rg_patterns();
+            let result = Tui::new().and_then(|tui| tui.start(rg_cmdline, rg_messages, patterns));
 
             // Restore terminal.
             if let Err(err) = Tui::restore_terminal() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,9 +92,8 @@ mod rg;
 mod ui;
 mod util;
 
-use std::env;
 use std::fs::File;
-use std::process;
+use std::{env, process};
 
 use anyhow::Result;
 use clap::crate_name;

--- a/src/model/printable.rs
+++ b/src/model/printable.rs
@@ -187,9 +187,10 @@ impl Printable for Vec<u8> {
 
 #[cfg(test)]
 mod tests {
+    use base64_simd::STANDARD as base64;
+
     use crate::model::{Printable, PrintableStyle};
     use crate::rg::de::ArbitraryData;
-    use base64_simd::STANDARD as base64;
 
     const NON_PRINTABLE_WHITESPACE: &str = "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0A\x0B\x0C\x0D\x0E\x0F\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1A\x1B\x1C\x1D\x1E\x1F\x20\x7F";
 

--- a/src/model/printable.rs
+++ b/src/model/printable.rs
@@ -179,6 +179,12 @@ impl Printable for ArbitraryData {
     }
 }
 
+impl Printable for Vec<u8> {
+    fn to_printable(&self, style: PrintableStyle) -> String {
+        String::from_utf8_lossy(self).to_printable(style)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::model::{Printable, PrintableStyle};

--- a/src/model/replacement.rs
+++ b/src/model/replacement.rs
@@ -1,21 +1,28 @@
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 
+use regex::bytes::Regex;
+
 use crate::rg::de::{ArbitraryData, RgMessageKind};
 use crate::ui::line::Item;
 
 #[derive(Debug)]
 pub struct ReplacementCriteria {
+    pub capture_pattern: Option<Regex>,
     pub items: Vec<Item>,
-    pub text: String,
+    pub user_replacement: Vec<u8>,
     pub encoding: Option<String>,
 }
 
 impl ReplacementCriteria {
-    pub fn new<S: AsRef<str>>(text: S, items: Vec<Item>) -> ReplacementCriteria {
-        let text = text.as_ref().to_owned();
+    pub fn new<S: AsRef<str>>(
+        capture_pattern: Option<Regex>,
+        user_replacement: S,
+        items: Vec<Item>,
+    ) -> ReplacementCriteria {
         ReplacementCriteria {
-            text,
+            capture_pattern,
+            user_replacement: user_replacement.as_ref().as_bytes().to_vec(),
             items,
             encoding: None,
         }

--- a/src/replace.rs
+++ b/src/replace.rs
@@ -1,5 +1,4 @@
-use std::fs::File;
-use std::fs::OpenOptions;
+use std::fs::{File, OpenOptions};
 use std::io::{Read, Write};
 
 use anyhow::{anyhow, Context, Result};
@@ -503,6 +502,7 @@ mod tests {
         use std::ffi::OsStr;
         use std::os::unix::ffi::OsStrExt;
         use std::path::PathBuf;
+
         use tempfile::tempdir;
 
         // Here, the values 0x66 and 0x6f correspond to 'f' and 'o'

--- a/src/replace.rs
+++ b/src/replace.rs
@@ -68,6 +68,8 @@ fn perform_replacements_in_file(
         let offset = item.offset().unwrap();
         log::debug!("Item[{}] offset: {}", i, offset);
 
+        let mut byte_buf = Vec::new();
+
         // Iterate backwards so the offset doesn't change as we make replacements.
         for (i, sub_item) in item
             .sub_items()
@@ -84,14 +86,35 @@ fn perform_replacements_in_file(
             let matched_bytes = text.to_vec();
 
             if str_to_remove.as_bytes() == matched_bytes.as_slice() {
+                // compute replacement
+                let replacement = match criteria
+                    .capture_pattern
+                    .as_ref()
+                    .and_then(|re| re.captures(&matched_bytes))
+                {
+                    // user passed a capturing group
+                    Some(captures) => {
+                        // empty buf without changing capacity
+                        byte_buf.clear();
+                        captures.expand(&criteria.user_replacement, &mut byte_buf);
+                        byte_buf.as_slice()
+                    }
+                    // just use raw replacement
+                    None => criteria.user_replacement.as_slice(),
+                };
+
+                // have to save this because it will be invalid after the replacement
                 let removed_str = str_to_remove.to_string();
-                file_as_str.replace_range(normalised_range, &criteria.text);
+                // must convert to strings since due to encoding support we perform replacements as strings
+                let replacement = std::str::from_utf8(&replacement)?;
+                // performance replacement
+                file_as_str.replace_range(normalised_range, replacement);
 
                 log::debug!(
                     "Replacement - reported line: {:?}, removed: \"{}\", added: \"{}\"",
                     item.line_number(),
                     removed_str,
-                    criteria.text
+                    replacement
                 );
             } else {
                 log::warn!("Matched bytes do not match bytes to replace!");
@@ -151,13 +174,18 @@ fn perform_replacements_in_file(
 
 pub fn perform_replacements(criteria: ReplacementCriteria) -> Result<()> {
     log::trace!("--- PERFORM REPLACEMENTS ---");
-    log::debug!("Replacement text: \"{}\"", criteria.text);
+    log::debug!(
+        "Replacement text: \"{}\"",
+        String::from_utf8_lossy(&criteria.user_replacement)
+    );
 
     let rg_encoding = RgEncoding::from(&criteria.encoding);
     log::debug!("User passed encoding: {:?}", rg_encoding);
 
     // Group items by their file so we only open each file once.
     let mut did_skip_replacement = false;
+
+    // TODO: consider concurrent replacements here - make it configurable - we don't want to read in multiple large files at once
     for meta in criteria.as_map() {
         match perform_replacements_in_file(&criteria, &rg_encoding, meta) {
             Ok(did_skip) => {
@@ -261,7 +289,7 @@ mod tests {
             build_item(RgMessageKind::Summary, &p5),
         ];
 
-        perform_replacements(ReplacementCriteria::new("NEW_VALUE", items)).unwrap();
+        perform_replacements(ReplacementCriteria::new(None, "NEW_VALUE", items)).unwrap();
         assert_eq!(fs::read_to_string(p1).unwrap(), text);
         assert_eq!(fs::read_to_string(p2).unwrap(), text);
         assert_eq!(fs::read_to_string(p3).unwrap(), "NEW_VALUE bar baz");
@@ -288,7 +316,7 @@ mod tests {
         assert_eq!(perms().mode(), 0o100777);
 
         // perform replacement
-        perform_replacements(ReplacementCriteria::new("NEW_VALUE", vec![item])).unwrap();
+        perform_replacements(ReplacementCriteria::new(None, "NEW_VALUE", vec![item])).unwrap();
         assert_eq!(fs::read_to_string(&path).unwrap(), "NEW_VALUE bar baz");
 
         // now check permissions are what we expect
@@ -302,7 +330,7 @@ mod tests {
         let (item3, p3) = temp_item!(0, "bar baz foo", vec![SubMatch::new_text("foo", 8..11)]);
 
         let items = vec![item1, item2, item3];
-        perform_replacements(ReplacementCriteria::new("NEW_VALUE", items)).unwrap();
+        perform_replacements(ReplacementCriteria::new(None, "NEW_VALUE", items)).unwrap();
         assert_eq!(fs::read_to_string(p1).unwrap(), "NEW_VALUE bar baz");
         assert_eq!(fs::read_to_string(p2).unwrap(), "baz NEW_VALUE bar");
         assert_eq!(fs::read_to_string(p3).unwrap(), "bar baz NEW_VALUE");
@@ -320,7 +348,7 @@ mod tests {
         items[1].set_should_replace(0, true);
         items[2].set_should_replace(0, false);
 
-        perform_replacements(ReplacementCriteria::new("NEW_VALUE", items)).unwrap();
+        perform_replacements(ReplacementCriteria::new(None, "NEW_VALUE", items)).unwrap();
         assert_eq!(fs::read_to_string(p1).unwrap(), "foo bar baz");
         assert_eq!(fs::read_to_string(p2).unwrap(), "baz NEW_VALUE bar");
         assert_eq!(fs::read_to_string(p3).unwrap(), "bar baz foo");
@@ -338,7 +366,7 @@ mod tests {
             ]
         );
 
-        perform_replacements(ReplacementCriteria::new("NEW_VALUE", vec![item])).unwrap();
+        perform_replacements(ReplacementCriteria::new(None, "NEW_VALUE", vec![item])).unwrap();
         assert_eq!(
             fs::read_to_string(p).unwrap(),
             "NEW_VALUE NEW_VALUE NEW_VALUE"
@@ -380,7 +408,7 @@ mod tests {
             ),
         ];
 
-        perform_replacements(ReplacementCriteria::new("NEW_VALUE", items)).unwrap();
+        perform_replacements(ReplacementCriteria::new(None, "NEW_VALUE", items)).unwrap();
         assert_eq!(
             fs::read_to_string(p).unwrap(),
             "NEW_VALUE bar baz\n...\nbaz NEW_VALUE bar\n...\nbar baz NEW_VALUE"
@@ -413,7 +441,7 @@ mod tests {
             ),
         ];
 
-        perform_replacements(ReplacementCriteria::new("NEW_VALUE", items)).unwrap();
+        perform_replacements(ReplacementCriteria::new(None, "NEW_VALUE", items)).unwrap();
         assert_eq!(
             fs::read_to_string(p).unwrap(),
             "foo bar baz\n...\nbaz NEW_VALUE bar\n...\nbar NEW_VALUE foo"
@@ -450,7 +478,7 @@ mod tests {
                 .build(),
         );
 
-        perform_replacements(ReplacementCriteria::new(" on", vec![item])).unwrap();
+        perform_replacements(ReplacementCriteria::new(None, " on", vec![item])).unwrap();
         assert_eq!(fs::read_to_string(p).unwrap(), "hell on earth");
     }
 
@@ -479,7 +507,7 @@ mod tests {
                     })
                     .collect();
 
-                perform_replacements(ReplacementCriteria::new($replace, items)).unwrap();
+                perform_replacements(ReplacementCriteria::new(None, $replace, items)).unwrap();
 
                 // Read file bytes.
                 let mut file_bytes = vec![];

--- a/src/rg/de.rs
+++ b/src/rg/de.rs
@@ -161,7 +161,9 @@ mod tests {
 
     use pretty_assertions::assert_eq;
 
-    use super::{ArbitraryData::*, RgMessage::*, *};
+    use super::ArbitraryData::*;
+    use super::RgMessage::*;
+    use super::*;
 
     #[test]
     fn arbitrary_data() {

--- a/src/ui/app/app_events.rs
+++ b/src/ui/app/app_events.rs
@@ -4,7 +4,7 @@ use crossterm::event::{Event, KeyCode, KeyModifiers};
 use either::Either;
 use tui::layout::Rect;
 
-use crate::model::{Movement, ReplacementCriteria};
+use crate::model::Movement;
 use crate::rg::de::RgMessageKind;
 use crate::ui::app::{App, AppState, AppUiState};
 use crate::util::{byte_pos_from_char_pos, clamp};
@@ -71,10 +71,8 @@ impl App {
                                 AppUiState::InputReplacement(replacement.to_owned(), *pos)
                         }
                         KeyCode::Enter => {
-                            self.state = AppState::Complete(ReplacementCriteria::new(
-                                replacement,
-                                self.list.clone(),
-                            ));
+                            self.state = AppState::Complete;
+                            return Ok(());
                         }
                         _ => {}
                     },
@@ -192,7 +190,7 @@ impl App {
         Ok(())
     }
 
-    fn move_horizonally(&mut self, movement: &Movement) -> bool {
+    fn move_horizontally(&mut self, movement: &Movement) -> bool {
         let selected_item = self.list_state.selected_item();
         let selected_match = self.list_state.selected_submatch();
 
@@ -316,7 +314,7 @@ impl App {
     }
 
     pub(crate) fn move_pos(&mut self, movement: Movement, term_size: Rect) {
-        if !self.move_horizonally(&movement) {
+        if !self.move_horizontally(&movement) {
             self.move_vertically(&movement);
         }
 
@@ -438,7 +436,7 @@ mod tests {
     }
 
     fn new_app() -> App {
-        App::new("TESTS".to_string(), rg_messages())
+        App::new(None, "TESTS".to_string(), rg_messages())
     }
 
     fn new_app_multiple_files() -> App {
@@ -454,7 +452,7 @@ mod tests {
         messages_multiple_files.extend(messages_multiple_files.clone());
         messages_multiple_files.push(RgMessage::from_str(RG_JSON_SUMMARY));
 
-        App::new("TESTS".to_string(), messages_multiple_files)
+        App::new(None, "TESTS".to_string(), messages_multiple_files)
     }
 
     type PosTriple = (usize, usize, usize);
@@ -488,7 +486,7 @@ mod tests {
             RgMessage::from_str(RG_JSON_SUMMARY),
         ];
 
-        App::new("TESTS".to_string(), messages)
+        App::new(None, "TESTS".to_string(), messages)
     }
 
     // Valid positions for the app returned by `new_app_line_wrapping`.

--- a/src/ui/app/app_render.rs
+++ b/src/ui/app/app_render.rs
@@ -269,7 +269,8 @@ impl App {
         let window_end = window_start + window_height;
 
         let ctx = &UiItemContext {
-            replacement_text: self.ui_state.get_replacement_text(),
+            capture_pattern: self.capture_pattern.as_ref(),
+            replacement_text: self.ui_state.user_replacement_text(),
             printable_style: self.printable_style,
             app_list_state: &self.list_state,
             app_ui_state: &self.ui_state,

--- a/src/ui/app/mod.rs
+++ b/src/ui/app/mod.rs
@@ -2,13 +2,14 @@ mod app_events;
 mod app_render;
 mod state;
 
-use crate::model::{PrintableStyle, ReplacementCriteria};
-use crate::rg::de::{RgMessage, Stats};
-use crate::ui::line::Item;
 use anyhow::{bail, Result};
 use regex::bytes::Regex;
 use state::HelpTextState;
 pub use state::{AppListState, AppState, AppUiState};
+
+use crate::model::{PrintableStyle, ReplacementCriteria};
+use crate::rg::de::{RgMessage, Stats};
+use crate::ui::line::Item;
 
 const HELP_TEXT: &str = include_str!("../../../doc/rgr.1.template");
 

--- a/src/ui/app/mod.rs
+++ b/src/ui/app/mod.rs
@@ -2,9 +2,11 @@ mod app_events;
 mod app_render;
 mod state;
 
-use crate::model::PrintableStyle;
+use crate::model::{PrintableStyle, ReplacementCriteria};
 use crate::rg::de::{RgMessage, Stats};
 use crate::ui::line::Item;
+use anyhow::{bail, Result};
+use regex::bytes::Regex;
 use state::HelpTextState;
 pub use state::{AppListState, AppState, AppUiState};
 
@@ -13,18 +15,33 @@ const HELP_TEXT: &str = include_str!("../../../doc/rgr.1.template");
 pub struct App {
     pub state: AppState,
 
+    /// If the user passed a regular expression with a capturing group, then this will be set to
+    /// indicate that we should use the capturing group when performing replacements.
+    capture_pattern: Option<Regex>,
+
+    /// Raw args passed to `ripgrep`.
     rg_cmdline: String,
+    /// Stats from `ripgrep`'s JSON output
     stats: Stats,
+    /// A list that represents all matches and holds each match's state.
     list: Vec<Item>,
+    /// State for where the user is inside the list.
     list_state: AppListState,
+    /// Current UI mode.
     ui_state: AppUiState,
+    /// Holds state information used when rendering the help screen.
     help_text_state: HelpTextState,
 
+    /// The current printable style used to render text.
     printable_style: PrintableStyle,
 }
 
 impl App {
-    pub fn new(rg_cmdline: String, rg_messages: Vec<RgMessage>) -> App {
+    pub fn new(
+        capture_pattern: Option<Regex>,
+        rg_cmdline: String,
+        rg_messages: Vec<RgMessage>,
+    ) -> App {
         let mut list = vec![];
         let mut maybe_stats = None;
 
@@ -42,6 +59,7 @@ impl App {
         App {
             state: AppState::Running,
 
+            capture_pattern,
             rg_cmdline,
             stats: maybe_stats.expect("failed to find RgMessage::Summary from rg!"),
             list_state: AppListState::new(),
@@ -49,6 +67,23 @@ impl App {
             ui_state: AppUiState::SelectMatches,
             help_text_state: HelpTextState::new(HELP_TEXT),
             printable_style: PrintableStyle::default(),
+        }
+    }
+
+    /// Consume the app and return `ReplacementCriteria`. This will return an `Err` if the app wasn't
+    /// in a state where the user had entered any replacement text.
+    pub fn get_replacement_criteria(self) -> Result<ReplacementCriteria> {
+        match self.ui_state {
+            AppUiState::InputReplacement(user_replacement, _)
+            | AppUiState::ConfirmReplacement(user_replacement, _) => Ok(ReplacementCriteria::new(
+                self.capture_pattern,
+                user_replacement,
+                self.list,
+            )),
+            other => bail!(
+                "unexpected app ui state when calling App::get_replacement_criteria: {:?}",
+                other
+            ),
         }
     }
 }

--- a/src/ui/app/state.rs
+++ b/src/ui/app/state.rs
@@ -2,8 +2,6 @@ use tui::style::{Color, Style};
 use tui::text::Span;
 use tui::widgets::ListState;
 
-use crate::model::ReplacementCriteria;
-
 #[derive(Debug)]
 pub struct AppListState {
     /// The selected "item" in the list of items received from rg
@@ -67,7 +65,7 @@ impl AppListState {
 pub enum AppState {
     Running,
     Cancelled,
-    Complete(ReplacementCriteria),
+    Complete,
 }
 
 /// Describes the various states that `App` can be in.
@@ -93,7 +91,7 @@ impl AppUiState {
         )
     }
 
-    pub fn get_replacement_text(&self) -> Option<&str> {
+    pub fn user_replacement_text(&self) -> Option<&str> {
         match &self {
             AppUiState::InputReplacement(replacement, _)
             | AppUiState::ConfirmReplacement(replacement, _) => Some(replacement.as_str()),

--- a/src/ui/line/item.rs
+++ b/src/ui/line/item.rs
@@ -466,6 +466,7 @@ mod tests {
     use base64_simd::STANDARD as base64;
     use insta::assert_debug_snapshot;
     use pretty_assertions::assert_eq;
+    use regex::bytes::Regex;
     use tui::layout::Rect;
 
     use crate::model::*;
@@ -666,6 +667,36 @@ mod tests {
         let app_list_state = new_app_list_state();
         let app_ui_state = AppUiState::ConfirmReplacement(String::from(replacement), 0);
         let ctx = new_ui_item_ctx(Some(replacement), &app_list_state, &app_ui_state);
+
+        assert_debug_snapshot!(new_item(RG_JSON_BEGIN).to_span_lines(&ctx));
+        assert_debug_snapshot!(new_item(RG_JSON_MATCH).to_span_lines(&ctx));
+        assert_debug_snapshot!(new_item(RG_JSON_CONTEXT).to_span_lines(&ctx));
+        assert_debug_snapshot!(new_item(RG_JSON_END).to_span_lines(&ctx));
+    }
+
+    #[test]
+    fn to_span_lines_with_text_input_replacement_and_capture_pattern() {
+        let replacement = "${2}($1)";
+        let app_list_state = new_app_list_state();
+        let app_ui_state = AppUiState::InputReplacement(String::from(replacement), 0);
+        let mut ctx = new_ui_item_ctx(Some(replacement), &app_list_state, &app_ui_state);
+        let re = Regex::new(r"(new)\((rg_msg)\)").unwrap();
+        ctx.capture_pattern = Some(&re);
+
+        assert_debug_snapshot!(new_item(RG_JSON_BEGIN).to_span_lines(&ctx));
+        assert_debug_snapshot!(new_item(RG_JSON_MATCH).to_span_lines(&ctx));
+        assert_debug_snapshot!(new_item(RG_JSON_CONTEXT).to_span_lines(&ctx));
+        assert_debug_snapshot!(new_item(RG_JSON_END).to_span_lines(&ctx));
+    }
+
+    #[test]
+    fn to_span_lines_with_text_confirm_replacement_and_capture_pattern() {
+        let replacement = "${2}($1)";
+        let app_list_state = new_app_list_state();
+        let app_ui_state = AppUiState::ConfirmReplacement(String::from(replacement), 0);
+        let mut ctx = new_ui_item_ctx(Some(replacement), &app_list_state, &app_ui_state);
+        let re = Regex::new(r"(new)\((rg_msg)\)").unwrap();
+        ctx.capture_pattern = Some(&re);
 
         assert_debug_snapshot!(new_item(RG_JSON_BEGIN).to_span_lines(&ctx));
         assert_debug_snapshot!(new_item(RG_JSON_MATCH).to_span_lines(&ctx));

--- a/src/ui/line/item.rs
+++ b/src/ui/line/item.rs
@@ -553,9 +553,10 @@ mod tests {
     #[test]
     #[cfg(unix)]
     fn path_with_base64() {
-        use crate::rg::de::test_utilities::RgMessageBuilder;
         use std::ffi::OsStr;
         use std::os::unix::ffi::OsStrExt;
+
+        use crate::rg::de::test_utilities::RgMessageBuilder;
 
         // Here, the values 0x66 and 0x6f correspond to 'f' and 'o'
         // respectively. The value 0x80 is a lone continuation byte, invalid

--- a/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_text_confirm_replacement_and_capture_pattern-2.snap
+++ b/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_text_confirm_replacement_and_capture_pattern-2.snap
@@ -1,0 +1,70 @@
+---
+source: src/ui/line/item.rs
+expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
+---
+[
+    Spans(
+        [
+            Span {
+                content: "197:",
+                style: Style {
+                    fg: Some(
+                        DarkGray,
+                    ),
+                    bg: None,
+                    add_modifier: (empty),
+                    sub_modifier: (empty),
+                },
+            },
+            Span {
+                content: "    ",
+                style: Style {
+                    fg: None,
+                    bg: None,
+                    add_modifier: (empty),
+                    sub_modifier: (empty),
+                },
+            },
+            Span {
+                content: "rg_msg(new)",
+                style: Style {
+                    fg: Some(
+                        Green,
+                    ),
+                    bg: None,
+                    add_modifier: (empty),
+                    sub_modifier: (empty),
+                },
+            },
+            Span {
+                content: "::new(",
+                style: Style {
+                    fg: None,
+                    bg: None,
+                    add_modifier: (empty),
+                    sub_modifier: (empty),
+                },
+            },
+            Span {
+                content: "rg_msg(new)",
+                style: Style {
+                    fg: Some(
+                        Green,
+                    ),
+                    bg: None,
+                    add_modifier: (empty),
+                    sub_modifier: (empty),
+                },
+            },
+            Span {
+                content: ")",
+                style: Style {
+                    fg: None,
+                    bg: None,
+                    add_modifier: (empty),
+                    sub_modifier: (empty),
+                },
+            },
+        ],
+    ),
+]

--- a/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_text_confirm_replacement_and_capture_pattern-3.snap
+++ b/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_text_confirm_replacement_and_capture_pattern-3.snap
@@ -1,0 +1,30 @@
+---
+source: src/ui/line/item.rs
+expression: new_item(RG_JSON_CONTEXT).to_span_lines(&ctx)
+---
+[
+    Spans(
+        [
+            Span {
+                content: "198:",
+                style: Style {
+                    fg: Some(
+                        DarkGray,
+                    ),
+                    bg: None,
+                    add_modifier: (empty),
+                    sub_modifier: (empty),
+                },
+            },
+            Span {
+                content: "  }",
+                style: Style {
+                    fg: None,
+                    bg: None,
+                    add_modifier: (empty),
+                    sub_modifier: (empty),
+                },
+            },
+        ],
+    ),
+]

--- a/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_text_confirm_replacement_and_capture_pattern-4.snap
+++ b/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_text_confirm_replacement_and_capture_pattern-4.snap
@@ -1,0 +1,19 @@
+---
+source: src/ui/line/item.rs
+expression: new_item(RG_JSON_END).to_span_lines(&ctx)
+---
+[
+    Spans(
+        [
+            Span {
+                content: "",
+                style: Style {
+                    fg: None,
+                    bg: None,
+                    add_modifier: (empty),
+                    sub_modifier: (empty),
+                },
+            },
+        ],
+    ),
+]

--- a/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_text_confirm_replacement_and_capture_pattern.snap
+++ b/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_text_confirm_replacement_and_capture_pattern.snap
@@ -1,0 +1,21 @@
+---
+source: src/ui/line/item.rs
+expression: new_item(RG_JSON_BEGIN).to_span_lines(&ctx)
+---
+[
+    Spans(
+        [
+            Span {
+                content: "src/model/item.rs",
+                style: Style {
+                    fg: Some(
+                        Magenta,
+                    ),
+                    bg: None,
+                    add_modifier: (empty),
+                    sub_modifier: (empty),
+                },
+            },
+        ],
+    ),
+]

--- a/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_text_input_replacement_and_capture_pattern-2.snap
+++ b/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_text_input_replacement_and_capture_pattern-2.snap
@@ -1,0 +1,92 @@
+---
+source: src/ui/line/item.rs
+expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
+---
+[
+    Spans(
+        [
+            Span {
+                content: "197:",
+                style: Style {
+                    fg: Some(
+                        DarkGray,
+                    ),
+                    bg: None,
+                    add_modifier: (empty),
+                    sub_modifier: (empty),
+                },
+            },
+            Span {
+                content: "    ",
+                style: Style {
+                    fg: None,
+                    bg: None,
+                    add_modifier: (empty),
+                    sub_modifier: (empty),
+                },
+            },
+            Span {
+                content: "Item",
+                style: Style {
+                    fg: Some(
+                        Red,
+                    ),
+                    bg: None,
+                    add_modifier: CROSSED_OUT,
+                    sub_modifier: (empty),
+                },
+            },
+            Span {
+                content: "rg_msg(new)",
+                style: Style {
+                    fg: Some(
+                        Green,
+                    ),
+                    bg: None,
+                    add_modifier: (empty),
+                    sub_modifier: (empty),
+                },
+            },
+            Span {
+                content: "::new(",
+                style: Style {
+                    fg: None,
+                    bg: None,
+                    add_modifier: (empty),
+                    sub_modifier: (empty),
+                },
+            },
+            Span {
+                content: "rg_msg",
+                style: Style {
+                    fg: Some(
+                        Red,
+                    ),
+                    bg: None,
+                    add_modifier: CROSSED_OUT,
+                    sub_modifier: (empty),
+                },
+            },
+            Span {
+                content: "rg_msg(new)",
+                style: Style {
+                    fg: Some(
+                        Green,
+                    ),
+                    bg: None,
+                    add_modifier: (empty),
+                    sub_modifier: (empty),
+                },
+            },
+            Span {
+                content: ")",
+                style: Style {
+                    fg: None,
+                    bg: None,
+                    add_modifier: (empty),
+                    sub_modifier: (empty),
+                },
+            },
+        ],
+    ),
+]

--- a/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_text_input_replacement_and_capture_pattern-3.snap
+++ b/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_text_input_replacement_and_capture_pattern-3.snap
@@ -1,0 +1,30 @@
+---
+source: src/ui/line/item.rs
+expression: new_item(RG_JSON_CONTEXT).to_span_lines(&ctx)
+---
+[
+    Spans(
+        [
+            Span {
+                content: "198:",
+                style: Style {
+                    fg: Some(
+                        DarkGray,
+                    ),
+                    bg: None,
+                    add_modifier: (empty),
+                    sub_modifier: (empty),
+                },
+            },
+            Span {
+                content: "  }",
+                style: Style {
+                    fg: None,
+                    bg: None,
+                    add_modifier: (empty),
+                    sub_modifier: (empty),
+                },
+            },
+        ],
+    ),
+]

--- a/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_text_input_replacement_and_capture_pattern-4.snap
+++ b/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_text_input_replacement_and_capture_pattern-4.snap
@@ -1,0 +1,19 @@
+---
+source: src/ui/line/item.rs
+expression: new_item(RG_JSON_END).to_span_lines(&ctx)
+---
+[
+    Spans(
+        [
+            Span {
+                content: "",
+                style: Style {
+                    fg: None,
+                    bg: None,
+                    add_modifier: (empty),
+                    sub_modifier: (empty),
+                },
+            },
+        ],
+    ),
+]

--- a/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_text_input_replacement_and_capture_pattern.snap
+++ b/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_text_input_replacement_and_capture_pattern.snap
@@ -1,0 +1,21 @@
+---
+source: src/ui/line/item.rs
+expression: new_item(RG_JSON_BEGIN).to_span_lines(&ctx)
+---
+[
+    Spans(
+        [
+            Span {
+                content: "src/model/item.rs",
+                style: Style {
+                    fg: Some(
+                        Magenta,
+                    ),
+                    bg: None,
+                    add_modifier: (empty),
+                    sub_modifier: (empty),
+                },
+            },
+        ],
+    ),
+]

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -1,3 +1,4 @@
+use regex::bytes::Regex;
 use tui::layout::Rect;
 
 use crate::model::PrintableStyle;
@@ -5,6 +6,9 @@ use crate::ui::app::{AppListState, AppUiState};
 
 /// Used when building the UI from the App's state.
 pub struct UiItemContext<'a> {
+    /// Regex to use for capturing groups. If it's not provided, the user didn't
+    /// pass any capturing groups.
+    pub capture_pattern: Option<&'a Regex>,
     /// The replacement text the user has entered.
     pub replacement_text: Option<&'a str>,
     /// The current state of the matches list.

--- a/src/ui/tui.rs
+++ b/src/ui/tui.rs
@@ -1,34 +1,37 @@
-use std::io;
-use std::sync::mpsc;
+use std::io::{self, Stdout};
+use std::sync::mpsc::{self, Receiver};
 use std::thread;
 use std::time::{Duration, Instant};
 
 use anyhow::Result;
-use crossterm::event::{self, DisableMouseCapture, EnableMouseCapture};
+use crossterm::event::{self, Event, KeyCode};
 use crossterm::execute;
 use crossterm::terminal::{self, EnterAlternateScreen, LeaveAlternateScreen};
+use regex::bytes::Regex;
+use tui::layout::Rect;
+use tui::style::{Color, Style};
+use tui::widgets::{Block, Borders, Paragraph, Wrap};
 use tui::{backend::CrosstermBackend, Terminal};
 
 use crate::model::ReplacementCriteria;
 use crate::rg::de::RgMessage;
 use crate::ui::app::{App, AppState};
 
+const FALLBACK_MESSAGE: &str = r#"
+You may continue to use repgrep, however capturing groups will be ignored for this session."#;
+
 pub struct Tui {
-    app: App,
+    term: Terminal<CrosstermBackend<Stdout>>,
+    rx: Receiver<Event>,
 }
 
 impl Tui {
-    pub fn new(rg_cmdline: String, rg_messages: Vec<RgMessage>) -> Tui {
-        Tui {
-            app: App::new(rg_cmdline, rg_messages),
-        }
-    }
-
-    pub fn start(mut self) -> Result<Option<ReplacementCriteria>> {
+    pub fn new() -> Result<Tui> {
         terminal::enable_raw_mode()?;
 
         let mut stdout = io::stdout();
-        execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
+        // NOTE: must match options in `Self::restore_terminal()`
+        execute!(stdout, EnterAlternateScreen)?;
 
         let backend = CrosstermBackend::new(stdout);
         let mut term = Terminal::new(backend)?;
@@ -46,25 +49,146 @@ impl Tui {
 
         term.clear()?;
 
+        Ok(Tui { term, rx })
+    }
+
+    fn draw_message_box(&mut self, title: impl AsRef<str>, body: impl AsRef<str>) -> Result<()> {
+        self.term.clear()?;
+        self.term.draw(|f| {
+            let block = Block::default()
+                .style(Style::default().fg(Color::Red))
+                .borders(Borders::ALL)
+                .title(title.as_ref());
+
+            // TODO: check minimum size?
+            let frame = f.size();
+
+            // calculate message box size
+            let body = body.as_ref();
+            let body_lines = body.lines().count();
+            let block_frame = Rect::new(
+                frame.width / 4,
+                frame.height / 4,
+                frame.width / 2,
+                u16::min(
+                    frame.height / 2,
+                    // +6 accounting for borders and padding
+                    6 + body_lines as u16,
+                ),
+            );
+
+            // calculate inner paragraph bounds
+            let inner_frame = block.inner(block_frame);
+            let p_frame = Rect::new(
+                inner_frame.x.saturating_add(1),
+                inner_frame.y.saturating_add(1),
+                inner_frame.width.saturating_sub(1),
+                inner_frame.height.saturating_sub(1),
+            );
+
+            f.render_widget(block, block_frame);
+            f.render_widget(
+                Paragraph::new(body)
+                    .wrap(Wrap { trim: true })
+                    .style(Style::default().fg(Color::White)),
+                p_frame,
+            );
+        })?;
+
+        // display until user acknowledges
+        loop {
+            match self.rx.recv() {
+                Ok(Event::Key(key))
+                    if matches!(key.code, KeyCode::Enter | KeyCode::Esc | KeyCode::Char('q')) =>
+                {
+                    break
+                }
+
+                _ => continue,
+            }
+        }
+
+        self.term.clear()?;
+        Ok(())
+    }
+
+    pub fn start(
+        mut self,
+        rg_cmdline: String,
+        rg_messages: Vec<RgMessage>,
+        patterns: Vec<&str>,
+    ) -> Result<Option<ReplacementCriteria>> {
+        // Parse patterns into `Regex` structs
+        let patterns = patterns
+            .into_iter()
+            .map(|p| Regex::new(p))
+            .collect::<Result<Vec<_>, _>>();
+
+        // Check if we should be performing replacements with capturing groups.
+        let capture_pattern = match patterns {
+            // pattern with capturing group passed, and we only have one
+            Ok(mut one) if one.len() == 1 => {
+                // SAFETY: we just checked for length in this match
+                (one[0].captures_len() > 1).then_some(one.pop().unwrap())
+            }
+            // many patterns passed, and one had a capturing group
+            Ok(many) if many.iter().any(|re| re.captures_len() > 1) => {
+                self.draw_message_box(
+                    "Unsupported Arguments!",
+                    format!(
+                        "{}\n\nPatterns:\n\n{patterns}\n\n{fallback}",
+                        "Either pass a single pattern with capturing groups, or many patterns without capturing groups.",
+                        patterns = many
+                            .iter()
+                            .map(|re| format!("  - {}", re.as_str()))
+                            .collect::<Vec<_>>()
+                            .join("\n"),
+                            fallback = FALLBACK_MESSAGE
+                    ),
+                )?;
+
+                None
+            }
+            // many patterns passed, none had capturing groups
+            Ok(_) => None,
+            // failed to parse patterns
+            Err(e) => {
+                self.draw_message_box(
+                    "Error!",
+                    format!(
+                        "{}\n\nError: {}\n\n{fallback}",
+                        "Failed to pass patterns!",
+                        e,
+                        fallback = FALLBACK_MESSAGE
+                    ),
+                )?;
+
+                None
+            }
+        };
+
+        // main app event loop
+        let mut app = App::new(capture_pattern, rg_cmdline, rg_messages);
+        let mut term = self.term;
         loop {
             let before_draw = Instant::now();
-            term.draw(|mut f| self.app.draw(&mut f))?;
+            term.draw(|mut f| app.draw(&mut f))?;
 
             // If drawing to the terminal is slow, flush all keyboard events so they're not buffered.
             // (Otherwise with very slow updates, the user has to wait for all keyboard events to be processed
             // before being able to quit the app, etc).
             if before_draw.elapsed() > Duration::from_millis(20) {
-                while let Ok(_) = rx.try_recv() {}
+                while let Ok(_) = self.rx.try_recv() {}
             }
 
-            let event = rx.recv()?;
+            let event = self.rx.recv()?;
             let term_size = term.get_frame().size();
-            self.app.on_event(term_size, event)?;
+            app.on_event(term_size, event)?;
 
-            match self.app.state {
+            match app.state {
                 AppState::Running => continue,
                 AppState::Cancelled => return Ok(None),
-                AppState::Complete(replacement_criteria) => return Ok(Some(replacement_criteria)),
+                AppState::Complete => return Ok(Some(app.get_replacement_criteria()?)),
             }
         }
     }
@@ -74,11 +198,7 @@ impl Tui {
         let mut term = Terminal::new(backend)?;
 
         terminal::disable_raw_mode()?;
-        execute!(
-            term.backend_mut(),
-            LeaveAlternateScreen,
-            DisableMouseCapture
-        )?;
+        execute!(term.backend_mut(), LeaveAlternateScreen)?;
         term.show_cursor()?;
         term.clear()?;
         term.set_cursor(0, 0)?;

--- a/src/ui/tui.rs
+++ b/src/ui/tui.rs
@@ -8,10 +8,11 @@ use crossterm::event::{self, Event, KeyCode};
 use crossterm::execute;
 use crossterm::terminal::{self, EnterAlternateScreen, LeaveAlternateScreen};
 use regex::bytes::Regex;
+use tui::backend::CrosstermBackend;
 use tui::layout::Rect;
 use tui::style::{Color, Style};
 use tui::widgets::{Block, Borders, Paragraph, Wrap};
-use tui::{backend::CrosstermBackend, Terminal};
+use tui::Terminal;
 
 use crate::model::ReplacementCriteria;
 use crate::rg::de::RgMessage;

--- a/src/ui/tui.rs
+++ b/src/ui/tui.rs
@@ -132,6 +132,7 @@ impl Tui {
                 (one[0].captures_len() > 1).then_some(one.pop().unwrap())
             }
             // many patterns passed, and one had a capturing group
+            // all regex's have at least one capturing group, see: https://docs.rs/regex/1.8.4/regex/struct.Captures.html#method.len
             Ok(many) if many.iter().any(|re| re.captures_len() > 1) => {
                 self.draw_message_box(
                     "Unsupported Arguments!",


### PR DESCRIPTION
Fixes #89 

Notable additions:

* Support regular expression capturing groups
	* Refer to named groups (`/(?P<name>.)/`) with `$name` or `${name}`
	* Refer to any groups with its index, e.g. `$1` or `${1}`
	* Insert a `$` with `$$`
	* For more on this syntax, read [the `regex` crate's documentation](https://docs.rs/regex/1.8.4/regex/struct.Captures.html#method.expand)
* When files are detected as having `ascii` encoding, default to `utf8` since it's `ascii` compatible and more widely used

Remaining work:

* [x] tests for new capturing group behaviour