### PR TITLE
chore: move from unmaintained tui -> ratatui

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -408,22 +408,6 @@ dependencies = [
 
 [[package]]
 name = "crossterm"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
-dependencies = [
- "bitflags 1.3.2",
- "crossterm_winapi",
- "libc",
- "mio",
- "parking_lot",
- "signal-hook",
- "signal-hook-mio",
- "winapi",
-]
-
-[[package]]
-name = "crossterm"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a84cda67535339806297f1b331d6dd6320470d2a0fe65381e79ee9e156dd3d13"
@@ -649,6 +633,12 @@ dependencies = [
  "autocfg",
  "hashbrown",
 ]
+
+[[package]]
+name = "indoc"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c785eefb63ebd0e33416dfcb8d6da0bf27ce752843a45632a67bf10d4d4b5c4"
 
 [[package]]
 name = "insta"
@@ -913,6 +903,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8285baa38bdc9f879d92c0e37cb562ef38aa3aeefca22b3200186bc39242d3d5"
+dependencies = [
+ "bitflags 2.3.3",
+ "cassowary",
+ "crossterm",
+ "indoc",
+ "paste",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "rayon"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -984,7 +989,7 @@ dependencies = [
  "const_format",
  "criterion",
  "crossbeam-queue",
- "crossterm 0.26.1",
+ "crossterm",
  "either",
  "encoding",
  "flexi_logger",
@@ -995,6 +1000,7 @@ dependencies = [
  "num_cpus",
  "paste",
  "pretty_assertions",
+ "ratatui",
  "rayon",
  "regex",
  "safe-transmute",
@@ -1002,7 +1008,6 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "tempfile",
- "tui",
  "unicode-width",
 ]
 
@@ -1183,19 +1188,6 @@ checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "tui"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccdd26cbd674007e649a272da4475fb666d3aa0ad0531da7136db6fab0e5bad1"
-dependencies = [
- "bitflags 1.3.2",
- "cassowary",
- "crossterm 0.25.0",
- "unicode-segmentation",
- "unicode-width",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ serde = { version = "1.0.118", features = ["derive"] }
 serde_derive = "1.0.118"
 serde_json = "1.0.61"
 tempfile = "3.1.0"
-tui = { version = "0.19.0", default-features = false, features = ["crossterm"] }
+ratatui = { version = "0.22.0", default-features = false, features = ["crossterm"] }
 unicode-width = "0.1.8"
 
 [build-dependencies]

--- a/src/ui/app/app_events.rs
+++ b/src/ui/app/app_events.rs
@@ -887,12 +887,12 @@ mod tests {
 
     macro_rules! key {
         ($code:expr) => {
-            key!($code, KeyModifiers::empty())
+            key!($code, modifiers = KeyModifiers::empty())
         };
-        ($code:expr, $modifiers:expr) => {
+        ($code:expr, modifiers = $modifiers:expr) => {
             Event::Key(KeyEvent::new($code, $modifiers))
         };
-        ($code:expr, kind: $kind:expr) => {
+        ($code:expr, kind = $kind:expr) => {
             Event::Key({
                 let mut key = KeyEvent::new($code, KeyModifiers::empty());
                 key.kind = $kind;
@@ -922,14 +922,14 @@ mod tests {
         let mut app = new_app();
 
         // enter insert mode
-        send_key_assert!(app, key!(Enter, kind: KeyEventKind::Press), "", 0);
-        send_key_assert!(app, key!(Enter, kind: KeyEventKind::Repeat), "", 0);
-        send_key_assert!(app, key!(Enter, kind: KeyEventKind::Release), "", 0);
+        send_key_assert!(app, key!(Enter, kind = KeyEventKind::Press), "", 0);
+        send_key_assert!(app, key!(Enter, kind = KeyEventKind::Repeat), "", 0);
+        send_key_assert!(app, key!(Enter, kind = KeyEventKind::Release), "", 0);
 
         // insert text
-        send_key_assert!(app, key!(Char('a'), kind: KeyEventKind::Press), "a", 1);
-        send_key_assert!(app, key!(Char('a'), kind: KeyEventKind::Repeat), "a", 1);
-        send_key_assert!(app, key!(Char('a'), kind: KeyEventKind::Release), "a", 1);
+        send_key_assert!(app, key!(Char('a'), kind = KeyEventKind::Press), "a", 1);
+        send_key_assert!(app, key!(Char('a'), kind = KeyEventKind::Repeat), "a", 1);
+        send_key_assert!(app, key!(Char('a'), kind = KeyEventKind::Release), "a", 1);
     }
 
     #[test]
@@ -1006,7 +1006,7 @@ mod tests {
         send_key_assert!(app, key!(PageDown), "repgrep", 7);
 
         // move to next mode
-        send_key!(app, key!(Char('s'), KeyModifiers::CONTROL));
+        send_key!(app, key!(Char('s'), modifiers = KeyModifiers::CONTROL));
         assert_eq!(
             app.ui_state,
             AppUiState::ConfirmReplacement("repgrep".into(), 7)
@@ -1015,7 +1015,7 @@ mod tests {
         // move back and check pos
         send_key_assert!(app, key!(Esc), "repgrep", 7);
         send_key_assert!(app, key!(Left), "repgrep", 6);
-        send_key!(app, key!(Char('s'), KeyModifiers::CONTROL));
+        send_key!(app, key!(Char('s'), modifiers = KeyModifiers::CONTROL));
         assert_eq!(
             app.ui_state,
             AppUiState::ConfirmReplacement("repgrep".into(), 6)

--- a/src/ui/app/app_events.rs
+++ b/src/ui/app/app_events.rs
@@ -2,7 +2,7 @@
 use anyhow::Result;
 use crossterm::event::{Event, KeyCode, KeyEventKind, KeyModifiers};
 use either::Either;
-use tui::layout::Rect;
+use ratatui::layout::Rect;
 
 use crate::model::Movement;
 use crate::rg::de::RgMessageKind;
@@ -280,7 +280,7 @@ impl App {
 
     /// Update the UI's indicator position to point to the start of the selected item, and in the case of
     /// a match which spans multiple lines and has multiple submatches, the start of the selected submatch.
-    /// Note that this is also the mechanism which scrolls tui-rs' list interface.
+    /// Note that this is also the mechanism which scrolls ratatui's list interface.
     fn update_indicator(&mut self, term_size: Rect) {
         let item_idx = self.list_state.selected_item();
         let match_idx = self.list_state.selected_submatch();
@@ -397,7 +397,7 @@ impl App {
 mod tests {
     use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
     use pretty_assertions::assert_eq;
-    use tui::layout::Rect;
+    use ratatui::layout::Rect;
 
     use crate::model::Movement;
     use crate::rg::de::test_utilities::*;

--- a/src/ui/app/app_render.rs
+++ b/src/ui/app/app_render.rs
@@ -1,12 +1,12 @@
 /// Rendering for `App`.
 use clap::crate_name;
 use const_format::formatcp;
-use tui::backend::Backend;
-use tui::layout::{Alignment, Constraint, Direction, Layout, Rect};
-use tui::style::{Color, Modifier, Style};
-use tui::text::{Span, Spans, Text};
-use tui::widgets::{Block, Borders, List, ListItem, Paragraph, Row, Table, Wrap};
-use tui::Frame;
+use ratatui::backend::Backend;
+use ratatui::layout::{Alignment, Constraint, Direction, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span, Text};
+use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph, Row, Table, Wrap};
+use ratatui::Frame;
 
 use crate::model::Printable;
 use crate::rg::de::RgMessageKind;
@@ -61,7 +61,7 @@ impl App {
             .constraints([Constraint::Length(1), Constraint::Length(1)].as_ref())
             .split(root_split[1]);
 
-        (root_split, stats_and_input_split)
+        (root_split.to_vec(), stats_and_input_split.to_vec())
     }
 
     pub(crate) fn is_frame_too_small(&self, frame: Rect) -> bool {
@@ -101,7 +101,7 @@ impl App {
             )],
         };
 
-        let mut render_input = |spans| f.render_widget(Paragraph::new(Spans::from(spans)), r);
+        let mut render_input = |spans| f.render_widget(Paragraph::new(Line::from(spans)), r);
 
         // Draw input cursor after rendering input
         if let AppUiState::InputReplacement(input, _) = &self.ui_state {
@@ -144,8 +144,8 @@ impl App {
             .constraints([Constraint::Length(10), Constraint::Min(1)].as_ref())
             .split(r);
 
-        let left_side_items = vec![Spans::from(self.ui_state.to_span())];
-        let right_side_items = vec![Spans::from(vec![
+        let left_side_items = vec![Line::from(self.ui_state.to_span())];
+        let right_side_items = vec![Line::from(vec![
             Span::styled(
                 format!(" {} ", self.rg_cmdline),
                 Style::default().bg(Color::Blue).fg(Color::Black),
@@ -235,7 +235,7 @@ impl App {
 
         let help_title = Span::styled(format!("{} help", crate_name!()), title_style);
         let help_text = self.help_text_state.text(hsplit[0].height as usize);
-        let help_text = Text::from(help_text.as_ref());
+        let help_text = Text::from(help_text.as_str());
         let help_paragraph = Paragraph::new(help_text)
             .wrap(Wrap { trim: false })
             .block(Block::default().borders(Borders::ALL).title(help_title));

--- a/src/ui/app/state.rs
+++ b/src/ui/app/state.rs
@@ -1,6 +1,6 @@
-use tui::style::{Color, Style};
-use tui::text::Span;
-use tui::widgets::ListState;
+use ratatui::style::{Color, Style};
+use ratatui::text::Span;
+use ratatui::widgets::ListState;
 
 #[derive(Debug)]
 pub struct AppListState {

--- a/src/ui/line/item.rs
+++ b/src/ui/line/item.rs
@@ -1,8 +1,8 @@
 use std::ops::Range;
 use std::path::PathBuf;
 
-use tui::style::{Color, Style};
-use tui::text::{Span, Spans};
+use ratatui::style::{Color, Style};
+use ratatui::text::{Line, Span};
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use crate::format_line_number;
@@ -222,7 +222,7 @@ impl Item {
         count
     }
 
-    pub fn to_span_lines(&self, ctx: &UiItemContext) -> Vec<Spans> {
+    pub fn to_span_lines(&self, ctx: &UiItemContext) -> Vec<Line> {
         let is_replacing = ctx.app_ui_state.is_replacing();
         let is_selected = ctx.app_list_state.selected_item() == self.index;
 
@@ -325,7 +325,7 @@ impl Item {
                     }}
                 }
 
-                // Don't create a new Spans for the last line in the lines returned from the submatches or the replacement
+                // Don't create a new Line for the last line in the lines returned from the submatches or the replacement
                 // text, since there may be text appended afterwards to the lines later on (in the case of submatches, the
                 // replacement text, and for replacement text any remaining non-match text from the line).
                 macro_rules! new_line_if_needed {
@@ -413,7 +413,7 @@ impl Item {
         Self::wrap_span_lines(span_lines, max_width)
     }
 
-    fn wrap_span_lines(span_lines: Vec<Vec<Span>>, max_width: usize) -> Vec<Spans> {
+    fn wrap_span_lines(span_lines: Vec<Vec<Span>>, max_width: usize) -> Vec<Line> {
         span_lines
             .into_iter()
             .flat_map(|spans| {
@@ -435,7 +435,7 @@ impl Item {
                                     chars.drain(..).collect::<String>(),
                                     span.style,
                                 ));
-                                wrapped_spans.push(Spans::from(tmp.drain(..).collect::<Vec<_>>()));
+                                wrapped_spans.push(Line::from(tmp.drain(..).collect::<Vec<_>>()));
                                 len = 0;
                             }
 
@@ -452,7 +452,7 @@ impl Item {
                     }
                 }
 
-                wrapped_spans.push(Spans::from(tmp.drain(..).collect::<Vec<_>>()));
+                wrapped_spans.push(Line::from(tmp.drain(..).collect::<Vec<_>>()));
                 wrapped_spans
             })
             .collect()
@@ -466,8 +466,8 @@ mod tests {
     use base64_simd::STANDARD as base64;
     use insta::assert_debug_snapshot;
     use pretty_assertions::assert_eq;
+    use ratatui::layout::Rect;
     use regex::bytes::Regex;
-    use tui::layout::Rect;
 
     use crate::model::*;
     use crate::rg::de::test_utilities::*;

--- a/src/ui/line/snapshots/rgr__ui__line__item__tests__line_numbers_with_line_wrap_multi_submatch_input_replacement_multiline.snap
+++ b/src/ui/line/snapshots/rgr__ui__line__item__tests__line_numbers_with_line_wrap_multi_submatch_input_replacement_multiline.snap
@@ -3,8 +3,8 @@ source: src/ui/line/item.rs
 expression: new_item(RG_JSON_MATCH_LINE_WRAP_MULTI).to_span_lines(&ctx)
 ---
 [
-    Spans(
-        [
+    Line {
+        spans: [
             Span {
                 content: "1:",
                 style: Style {
@@ -12,8 +12,9 @@ expression: new_item(RG_JSON_MATCH_LINE_WRAP_MULTI).to_span_lines(&ctx)
                         DarkGray,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -21,8 +22,9 @@ expression: new_item(RG_JSON_MATCH_LINE_WRAP_MULTI).to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -32,8 +34,9 @@ expression: new_item(RG_JSON_MATCH_LINE_WRAP_MULTI).to_span_lines(&ctx)
                         Red,
                     ),
                     bg: None,
+                    underline_color: None,
                     add_modifier: CROSSED_OUT,
-                    sub_modifier: (empty),
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -43,14 +46,16 @@ expression: new_item(RG_JSON_MATCH_LINE_WRAP_MULTI).to_span_lines(&ctx)
                         Green,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
-    Spans(
-        [
+        alignment: None,
+    },
+    Line {
+        spans: [
             Span {
                 content: "+:",
                 style: Style {
@@ -58,8 +63,9 @@ expression: new_item(RG_JSON_MATCH_LINE_WRAP_MULTI).to_span_lines(&ctx)
                         DarkGray,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -69,8 +75,9 @@ expression: new_item(RG_JSON_MATCH_LINE_WRAP_MULTI).to_span_lines(&ctx)
                         Green,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -78,8 +85,9 @@ expression: new_item(RG_JSON_MATCH_LINE_WRAP_MULTI).to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -89,8 +97,9 @@ expression: new_item(RG_JSON_MATCH_LINE_WRAP_MULTI).to_span_lines(&ctx)
                         Red,
                     ),
                     bg: None,
+                    underline_color: None,
                     add_modifier: CROSSED_OUT,
-                    sub_modifier: (empty),
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -100,14 +109,16 @@ expression: new_item(RG_JSON_MATCH_LINE_WRAP_MULTI).to_span_lines(&ctx)
                         Green,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
-    Spans(
-        [
+        alignment: None,
+    },
+    Line {
+        spans: [
             Span {
                 content: "+:",
                 style: Style {
@@ -115,8 +126,9 @@ expression: new_item(RG_JSON_MATCH_LINE_WRAP_MULTI).to_span_lines(&ctx)
                         DarkGray,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -126,8 +138,9 @@ expression: new_item(RG_JSON_MATCH_LINE_WRAP_MULTI).to_span_lines(&ctx)
                         Green,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -135,8 +148,9 @@ expression: new_item(RG_JSON_MATCH_LINE_WRAP_MULTI).to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -146,8 +160,9 @@ expression: new_item(RG_JSON_MATCH_LINE_WRAP_MULTI).to_span_lines(&ctx)
                         Red,
                     ),
                     bg: None,
+                    underline_color: None,
                     add_modifier: CROSSED_OUT,
-                    sub_modifier: (empty),
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -157,14 +172,16 @@ expression: new_item(RG_JSON_MATCH_LINE_WRAP_MULTI).to_span_lines(&ctx)
                         Green,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
-    Spans(
-        [
+        alignment: None,
+    },
+    Line {
+        spans: [
             Span {
                 content: "+:",
                 style: Style {
@@ -172,8 +189,9 @@ expression: new_item(RG_JSON_MATCH_LINE_WRAP_MULTI).to_span_lines(&ctx)
                         DarkGray,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -183,8 +201,9 @@ expression: new_item(RG_JSON_MATCH_LINE_WRAP_MULTI).to_span_lines(&ctx)
                         Green,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -192,8 +211,9 @@ expression: new_item(RG_JSON_MATCH_LINE_WRAP_MULTI).to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -203,8 +223,9 @@ expression: new_item(RG_JSON_MATCH_LINE_WRAP_MULTI).to_span_lines(&ctx)
                         Red,
                     ),
                     bg: None,
+                    underline_color: None,
                     add_modifier: CROSSED_OUT,
-                    sub_modifier: (empty),
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -214,14 +235,16 @@ expression: new_item(RG_JSON_MATCH_LINE_WRAP_MULTI).to_span_lines(&ctx)
                         Green,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
-    Spans(
-        [
+        alignment: None,
+    },
+    Line {
+        spans: [
             Span {
                 content: "+:",
                 style: Style {
@@ -229,8 +252,9 @@ expression: new_item(RG_JSON_MATCH_LINE_WRAP_MULTI).to_span_lines(&ctx)
                         DarkGray,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -240,8 +264,9 @@ expression: new_item(RG_JSON_MATCH_LINE_WRAP_MULTI).to_span_lines(&ctx)
                         Green,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -249,8 +274,9 @@ expression: new_item(RG_JSON_MATCH_LINE_WRAP_MULTI).to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -260,8 +286,9 @@ expression: new_item(RG_JSON_MATCH_LINE_WRAP_MULTI).to_span_lines(&ctx)
                         Red,
                     ),
                     bg: None,
+                    underline_color: None,
                     add_modifier: CROSSED_OUT,
-                    sub_modifier: (empty),
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -271,14 +298,16 @@ expression: new_item(RG_JSON_MATCH_LINE_WRAP_MULTI).to_span_lines(&ctx)
                         Green,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
-    Spans(
-        [
+        alignment: None,
+    },
+    Line {
+        spans: [
             Span {
                 content: "+:",
                 style: Style {
@@ -286,8 +315,9 @@ expression: new_item(RG_JSON_MATCH_LINE_WRAP_MULTI).to_span_lines(&ctx)
                         DarkGray,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -297,8 +327,9 @@ expression: new_item(RG_JSON_MATCH_LINE_WRAP_MULTI).to_span_lines(&ctx)
                         Green,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -306,8 +337,9 @@ expression: new_item(RG_JSON_MATCH_LINE_WRAP_MULTI).to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -317,8 +349,9 @@ expression: new_item(RG_JSON_MATCH_LINE_WRAP_MULTI).to_span_lines(&ctx)
                         Red,
                     ),
                     bg: None,
+                    underline_color: None,
                     add_modifier: CROSSED_OUT,
-                    sub_modifier: (empty),
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -328,14 +361,16 @@ expression: new_item(RG_JSON_MATCH_LINE_WRAP_MULTI).to_span_lines(&ctx)
                         Green,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
-    Spans(
-        [
+        alignment: None,
+    },
+    Line {
+        spans: [
             Span {
                 content: "+:",
                 style: Style {
@@ -343,8 +378,9 @@ expression: new_item(RG_JSON_MATCH_LINE_WRAP_MULTI).to_span_lines(&ctx)
                         DarkGray,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -354,8 +390,9 @@ expression: new_item(RG_JSON_MATCH_LINE_WRAP_MULTI).to_span_lines(&ctx)
                         Green,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -363,8 +400,9 @@ expression: new_item(RG_JSON_MATCH_LINE_WRAP_MULTI).to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -374,8 +412,9 @@ expression: new_item(RG_JSON_MATCH_LINE_WRAP_MULTI).to_span_lines(&ctx)
                         Red,
                     ),
                     bg: None,
+                    underline_color: None,
                     add_modifier: CROSSED_OUT,
-                    sub_modifier: (empty),
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -385,14 +424,16 @@ expression: new_item(RG_JSON_MATCH_LINE_WRAP_MULTI).to_span_lines(&ctx)
                         Green,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
-    Spans(
-        [
+        alignment: None,
+    },
+    Line {
+        spans: [
             Span {
                 content: "+:",
                 style: Style {
@@ -400,8 +441,9 @@ expression: new_item(RG_JSON_MATCH_LINE_WRAP_MULTI).to_span_lines(&ctx)
                         DarkGray,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -411,8 +453,9 @@ expression: new_item(RG_JSON_MATCH_LINE_WRAP_MULTI).to_span_lines(&ctx)
                         Green,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -420,10 +463,12 @@ expression: new_item(RG_JSON_MATCH_LINE_WRAP_MULTI).to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
+        alignment: None,
+    },
 ]

--- a/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_input_replacement_trailing_line_feed-2.snap
+++ b/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_input_replacement_trailing_line_feed-2.snap
@@ -3,8 +3,8 @@ source: src/ui/line/item.rs
 expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
 ---
 [
-    Spans(
-        [
+    Line {
+        spans: [
             Span {
                 content: "197:",
                 style: Style {
@@ -12,8 +12,9 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                         DarkGray,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -21,8 +22,9 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -32,8 +34,9 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                         Red,
                     ),
                     bg: None,
+                    underline_color: None,
                     add_modifier: CROSSED_OUT,
-                    sub_modifier: (empty),
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -43,8 +46,9 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                         Green,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -52,8 +56,9 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -63,8 +68,9 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                         Red,
                     ),
                     bg: None,
+                    underline_color: None,
                     add_modifier: CROSSED_OUT,
-                    sub_modifier: (empty),
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -74,8 +80,9 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                         Green,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -83,10 +90,12 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
+        alignment: None,
+    },
 ]

--- a/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_input_replacement_trailing_line_feed.snap
+++ b/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_input_replacement_trailing_line_feed.snap
@@ -3,8 +3,8 @@ source: src/ui/line/item.rs
 expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
 ---
 [
-    Spans(
-        [
+    Line {
+        spans: [
             Span {
                 content: "197:",
                 style: Style {
@@ -12,8 +12,9 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                         DarkGray,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -21,8 +22,9 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -32,8 +34,9 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                         Red,
                     ),
                     bg: None,
+                    underline_color: None,
                     add_modifier: CROSSED_OUT,
-                    sub_modifier: (empty),
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -43,14 +46,16 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                         Green,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
-    Spans(
-        [
+        alignment: None,
+    },
+    Line {
+        spans: [
             Span {
                 content: "+:",
                 style: Style {
@@ -58,8 +63,9 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                         DarkGray,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -67,8 +73,9 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -76,8 +83,9 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -87,8 +95,9 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                         Red,
                     ),
                     bg: None,
+                    underline_color: None,
                     add_modifier: CROSSED_OUT,
-                    sub_modifier: (empty),
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -98,14 +107,16 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                         Green,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
-    Spans(
-        [
+        alignment: None,
+    },
+    Line {
+        spans: [
             Span {
                 content: "+:",
                 style: Style {
@@ -113,8 +124,9 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                         DarkGray,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -122,8 +134,9 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -131,10 +144,12 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
+        alignment: None,
+    },
 ]

--- a/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_line_wrapping-2.snap
+++ b/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_line_wrapping-2.snap
@@ -3,8 +3,8 @@ source: src/ui/line/item.rs
 expression: new_item(RG_JSON_CONTEXT_LINE_WRAP).to_span_lines(&ctx)
 ---
 [
-    Spans(
-        [
+    Line {
+        spans: [
             Span {
                 content: "4:",
                 style: Style {
@@ -12,8 +12,9 @@ expression: new_item(RG_JSON_CONTEXT_LINE_WRAP).to_span_lines(&ctx)
                         Yellow,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -23,14 +24,16 @@ expression: new_item(RG_JSON_CONTEXT_LINE_WRAP).to_span_lines(&ctx)
                         Yellow,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
-    Spans(
-        [
+        alignment: None,
+    },
+    Line {
+        spans: [
             Span {
                 content: "9*123456789(123456789_a_context_line",
                 style: Style {
@@ -38,10 +41,12 @@ expression: new_item(RG_JSON_CONTEXT_LINE_WRAP).to_span_lines(&ctx)
                         Yellow,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
+        alignment: None,
+    },
 ]

--- a/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_line_wrapping.snap
+++ b/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_line_wrapping.snap
@@ -3,8 +3,8 @@ source: src/ui/line/item.rs
 expression: new_item(RG_JSON_MATCH_LINE_WRAP).to_span_lines(&ctx)
 ---
 [
-    Spans(
-        [
+    Line {
+        spans: [
             Span {
                 content: "3:",
                 style: Style {
@@ -12,8 +12,9 @@ expression: new_item(RG_JSON_MATCH_LINE_WRAP).to_span_lines(&ctx)
                         Yellow,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -23,14 +24,16 @@ expression: new_item(RG_JSON_MATCH_LINE_WRAP).to_span_lines(&ctx)
                         Yellow,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
-    Spans(
-        [
+        alignment: None,
+    },
+    Line {
+        spans: [
             Span {
                 content: "9*123456789(123456789_",
                 style: Style {
@@ -38,8 +41,9 @@ expression: new_item(RG_JSON_MATCH_LINE_WRAP).to_span_lines(&ctx)
                         Yellow,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -51,8 +55,9 @@ expression: new_item(RG_JSON_MATCH_LINE_WRAP).to_span_lines(&ctx)
                     bg: Some(
                         Yellow,
                     ),
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -62,10 +67,12 @@ expression: new_item(RG_JSON_MATCH_LINE_WRAP).to_span_lines(&ctx)
                         Yellow,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
+        alignment: None,
+    },
 ]

--- a/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_line_wrapping_confirm_replacement-2.snap
+++ b/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_line_wrapping_confirm_replacement-2.snap
@@ -3,8 +3,8 @@ source: src/ui/line/item.rs
 expression: new_item(RG_JSON_CONTEXT_LINE_WRAP).to_span_lines(&ctx)
 ---
 [
-    Spans(
-        [
+    Line {
+        spans: [
             Span {
                 content: "4:",
                 style: Style {
@@ -12,8 +12,9 @@ expression: new_item(RG_JSON_CONTEXT_LINE_WRAP).to_span_lines(&ctx)
                         DarkGray,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -21,23 +22,27 @@ expression: new_item(RG_JSON_CONTEXT_LINE_WRAP).to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
-    Spans(
-        [
+        alignment: None,
+    },
+    Line {
+        spans: [
             Span {
                 content: "9*123456789(123456789_a_context_line",
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
+        alignment: None,
+    },
 ]

--- a/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_line_wrapping_confirm_replacement.snap
+++ b/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_line_wrapping_confirm_replacement.snap
@@ -3,8 +3,8 @@ source: src/ui/line/item.rs
 expression: new_item(RG_JSON_MATCH_LINE_WRAP).to_span_lines(&ctx)
 ---
 [
-    Spans(
-        [
+    Line {
+        spans: [
             Span {
                 content: "3:",
                 style: Style {
@@ -12,8 +12,9 @@ expression: new_item(RG_JSON_MATCH_LINE_WRAP).to_span_lines(&ctx)
                         DarkGray,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -21,21 +22,24 @@ expression: new_item(RG_JSON_MATCH_LINE_WRAP).to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
-    Spans(
-        [
+        alignment: None,
+    },
+    Line {
+        spans: [
             Span {
                 content: "9*123456789(123456789_",
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -45,8 +49,9 @@ expression: new_item(RG_JSON_MATCH_LINE_WRAP).to_span_lines(&ctx)
                         Green,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -54,10 +59,12 @@ expression: new_item(RG_JSON_MATCH_LINE_WRAP).to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
+        alignment: None,
+    },
 ]

--- a/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_line_wrapping_input_replacement-2.snap
+++ b/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_line_wrapping_input_replacement-2.snap
@@ -3,8 +3,8 @@ source: src/ui/line/item.rs
 expression: new_item(RG_JSON_CONTEXT_LINE_WRAP).to_span_lines(&ctx)
 ---
 [
-    Spans(
-        [
+    Line {
+        spans: [
             Span {
                 content: "4:",
                 style: Style {
@@ -12,8 +12,9 @@ expression: new_item(RG_JSON_CONTEXT_LINE_WRAP).to_span_lines(&ctx)
                         DarkGray,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -21,23 +22,27 @@ expression: new_item(RG_JSON_CONTEXT_LINE_WRAP).to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
-    Spans(
-        [
+        alignment: None,
+    },
+    Line {
+        spans: [
             Span {
                 content: "9*123456789(123456789_a_context_line",
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
+        alignment: None,
+    },
 ]

--- a/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_line_wrapping_input_replacement.snap
+++ b/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_line_wrapping_input_replacement.snap
@@ -3,8 +3,8 @@ source: src/ui/line/item.rs
 expression: new_item(RG_JSON_MATCH_LINE_WRAP).to_span_lines(&ctx)
 ---
 [
-    Spans(
-        [
+    Line {
+        spans: [
             Span {
                 content: "3:",
                 style: Style {
@@ -12,8 +12,9 @@ expression: new_item(RG_JSON_MATCH_LINE_WRAP).to_span_lines(&ctx)
                         DarkGray,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -21,21 +22,24 @@ expression: new_item(RG_JSON_MATCH_LINE_WRAP).to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
-    Spans(
-        [
+        alignment: None,
+    },
+    Line {
+        spans: [
             Span {
                 content: "9*123456789(123456789_",
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -45,8 +49,9 @@ expression: new_item(RG_JSON_MATCH_LINE_WRAP).to_span_lines(&ctx)
                         Red,
                     ),
                     bg: None,
+                    underline_color: None,
                     add_modifier: CROSSED_OUT,
-                    sub_modifier: (empty),
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -56,8 +61,9 @@ expression: new_item(RG_JSON_MATCH_LINE_WRAP).to_span_lines(&ctx)
                         Green,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -65,10 +71,12 @@ expression: new_item(RG_JSON_MATCH_LINE_WRAP).to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
+        alignment: None,
+    },
 ]

--- a/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_multiline_confirm_replacement_with_multiline_matches.snap
+++ b/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_multiline_confirm_replacement_with_multiline_matches.snap
@@ -3,8 +3,8 @@ source: src/ui/line/item.rs
 expression: new_item(RG_JSON_MATCH_MULTILINE).to_span_lines(&ctx)
 ---
 [
-    Spans(
-        [
+    Line {
+        spans: [
             Span {
                 content: "3:",
                 style: Style {
@@ -12,8 +12,9 @@ expression: new_item(RG_JSON_MATCH_MULTILINE).to_span_lines(&ctx)
                         DarkGray,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -21,8 +22,9 @@ expression: new_item(RG_JSON_MATCH_MULTILINE).to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -32,14 +34,16 @@ expression: new_item(RG_JSON_MATCH_MULTILINE).to_span_lines(&ctx)
                         Green,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
-    Spans(
-        [
+        alignment: None,
+    },
+    Line {
+        spans: [
             Span {
                 content: "+:",
                 style: Style {
@@ -47,8 +51,9 @@ expression: new_item(RG_JSON_MATCH_MULTILINE).to_span_lines(&ctx)
                         DarkGray,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -58,14 +63,16 @@ expression: new_item(RG_JSON_MATCH_MULTILINE).to_span_lines(&ctx)
                         Green,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
-    Spans(
-        [
+        alignment: None,
+    },
+    Line {
+        spans: [
             Span {
                 content: "+:",
                 style: Style {
@@ -73,8 +80,9 @@ expression: new_item(RG_JSON_MATCH_MULTILINE).to_span_lines(&ctx)
                         DarkGray,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -84,8 +92,9 @@ expression: new_item(RG_JSON_MATCH_MULTILINE).to_span_lines(&ctx)
                         Green,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -93,8 +102,9 @@ expression: new_item(RG_JSON_MATCH_MULTILINE).to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -104,14 +114,16 @@ expression: new_item(RG_JSON_MATCH_MULTILINE).to_span_lines(&ctx)
                         Green,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
-    Spans(
-        [
+        alignment: None,
+    },
+    Line {
+        spans: [
             Span {
                 content: "+:",
                 style: Style {
@@ -119,8 +131,9 @@ expression: new_item(RG_JSON_MATCH_MULTILINE).to_span_lines(&ctx)
                         DarkGray,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -130,14 +143,16 @@ expression: new_item(RG_JSON_MATCH_MULTILINE).to_span_lines(&ctx)
                         Green,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
-    Spans(
-        [
+        alignment: None,
+    },
+    Line {
+        spans: [
             Span {
                 content: "+:",
                 style: Style {
@@ -145,8 +160,9 @@ expression: new_item(RG_JSON_MATCH_MULTILINE).to_span_lines(&ctx)
                         DarkGray,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -156,8 +172,9 @@ expression: new_item(RG_JSON_MATCH_MULTILINE).to_span_lines(&ctx)
                         Green,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -165,10 +182,12 @@ expression: new_item(RG_JSON_MATCH_MULTILINE).to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
+        alignment: None,
+    },
 ]

--- a/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_multiline_input_replacement_with_multiline_matches.snap
+++ b/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_multiline_input_replacement_with_multiline_matches.snap
@@ -3,8 +3,8 @@ source: src/ui/line/item.rs
 expression: new_item(RG_JSON_MATCH_MULTILINE).to_span_lines(&ctx)
 ---
 [
-    Spans(
-        [
+    Line {
+        spans: [
             Span {
                 content: "3:",
                 style: Style {
@@ -12,8 +12,9 @@ expression: new_item(RG_JSON_MATCH_MULTILINE).to_span_lines(&ctx)
                         DarkGray,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -21,8 +22,9 @@ expression: new_item(RG_JSON_MATCH_MULTILINE).to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -32,14 +34,16 @@ expression: new_item(RG_JSON_MATCH_MULTILINE).to_span_lines(&ctx)
                         Red,
                     ),
                     bg: None,
+                    underline_color: None,
                     add_modifier: CROSSED_OUT,
-                    sub_modifier: (empty),
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
-    Spans(
-        [
+        alignment: None,
+    },
+    Line {
+        spans: [
             Span {
                 content: "-:",
                 style: Style {
@@ -47,8 +51,9 @@ expression: new_item(RG_JSON_MATCH_MULTILINE).to_span_lines(&ctx)
                         DarkGray,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -58,14 +63,16 @@ expression: new_item(RG_JSON_MATCH_MULTILINE).to_span_lines(&ctx)
                         Red,
                     ),
                     bg: None,
+                    underline_color: None,
                     add_modifier: CROSSED_OUT,
-                    sub_modifier: (empty),
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
-    Spans(
-        [
+        alignment: None,
+    },
+    Line {
+        spans: [
             Span {
                 content: "-:",
                 style: Style {
@@ -73,8 +80,9 @@ expression: new_item(RG_JSON_MATCH_MULTILINE).to_span_lines(&ctx)
                         DarkGray,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -84,8 +92,9 @@ expression: new_item(RG_JSON_MATCH_MULTILINE).to_span_lines(&ctx)
                         Red,
                     ),
                     bg: None,
+                    underline_color: None,
                     add_modifier: CROSSED_OUT,
-                    sub_modifier: (empty),
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -95,14 +104,16 @@ expression: new_item(RG_JSON_MATCH_MULTILINE).to_span_lines(&ctx)
                         Green,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
-    Spans(
-        [
+        alignment: None,
+    },
+    Line {
+        spans: [
             Span {
                 content: "+:",
                 style: Style {
@@ -110,8 +121,9 @@ expression: new_item(RG_JSON_MATCH_MULTILINE).to_span_lines(&ctx)
                         DarkGray,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -121,14 +133,16 @@ expression: new_item(RG_JSON_MATCH_MULTILINE).to_span_lines(&ctx)
                         Green,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
-    Spans(
-        [
+        alignment: None,
+    },
+    Line {
+        spans: [
             Span {
                 content: "+:",
                 style: Style {
@@ -136,8 +150,9 @@ expression: new_item(RG_JSON_MATCH_MULTILINE).to_span_lines(&ctx)
                         DarkGray,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -147,8 +162,9 @@ expression: new_item(RG_JSON_MATCH_MULTILINE).to_span_lines(&ctx)
                         Green,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -156,8 +172,9 @@ expression: new_item(RG_JSON_MATCH_MULTILINE).to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -167,8 +184,9 @@ expression: new_item(RG_JSON_MATCH_MULTILINE).to_span_lines(&ctx)
                         Red,
                     ),
                     bg: None,
+                    underline_color: None,
                     add_modifier: CROSSED_OUT,
-                    sub_modifier: (empty),
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -178,14 +196,16 @@ expression: new_item(RG_JSON_MATCH_MULTILINE).to_span_lines(&ctx)
                         Green,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
-    Spans(
-        [
+        alignment: None,
+    },
+    Line {
+        spans: [
             Span {
                 content: "+:",
                 style: Style {
@@ -193,8 +213,9 @@ expression: new_item(RG_JSON_MATCH_MULTILINE).to_span_lines(&ctx)
                         DarkGray,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -204,14 +225,16 @@ expression: new_item(RG_JSON_MATCH_MULTILINE).to_span_lines(&ctx)
                         Green,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
-    Spans(
-        [
+        alignment: None,
+    },
+    Line {
+        spans: [
             Span {
                 content: "+:",
                 style: Style {
@@ -219,8 +242,9 @@ expression: new_item(RG_JSON_MATCH_MULTILINE).to_span_lines(&ctx)
                         DarkGray,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -230,8 +254,9 @@ expression: new_item(RG_JSON_MATCH_MULTILINE).to_span_lines(&ctx)
                         Green,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -239,10 +264,12 @@ expression: new_item(RG_JSON_MATCH_MULTILINE).to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
+        alignment: None,
+    },
 ]

--- a/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_base64_lossy-2.snap
+++ b/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_base64_lossy-2.snap
@@ -3,17 +3,19 @@ source: src/ui/line/item.rs
 expression: new_item(RG_B64_JSON_END).to_span_lines(&ctx)
 ---
 [
-    Spans(
-        [
+    Line {
+        spans: [
             Span {
                 content: "",
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
+        alignment: None,
+    },
 ]

--- a/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_base64_lossy-3.snap
+++ b/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_base64_lossy-3.snap
@@ -3,8 +3,8 @@ source: src/ui/line/item.rs
 expression: new_item(RG_B64_JSON_MATCH).to_span_lines(&ctx)
 ---
 [
-    Spans(
-        [
+    Line {
+        spans: [
             Span {
                 content: "197:",
                 style: Style {
@@ -12,8 +12,9 @@ expression: new_item(RG_B64_JSON_MATCH).to_span_lines(&ctx)
                         DarkGray,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -21,8 +22,9 @@ expression: new_item(RG_B64_JSON_MATCH).to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -34,8 +36,9 @@ expression: new_item(RG_B64_JSON_MATCH).to_span_lines(&ctx)
                     bg: Some(
                         Red,
                     ),
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -43,8 +46,9 @@ expression: new_item(RG_B64_JSON_MATCH).to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -56,8 +60,9 @@ expression: new_item(RG_B64_JSON_MATCH).to_span_lines(&ctx)
                     bg: Some(
                         Red,
                     ),
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -65,10 +70,12 @@ expression: new_item(RG_B64_JSON_MATCH).to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
+        alignment: None,
+    },
 ]

--- a/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_base64_lossy-4.snap
+++ b/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_base64_lossy-4.snap
@@ -3,8 +3,8 @@ source: src/ui/line/item.rs
 expression: new_item(RG_B64_JSON_CONTEXT).to_span_lines(&ctx)
 ---
 [
-    Spans(
-        [
+    Line {
+        spans: [
             Span {
                 content: "198:",
                 style: Style {
@@ -12,8 +12,9 @@ expression: new_item(RG_B64_JSON_CONTEXT).to_span_lines(&ctx)
                         DarkGray,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -21,10 +22,12 @@ expression: new_item(RG_B64_JSON_CONTEXT).to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
+        alignment: None,
+    },
 ]

--- a/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_base64_lossy.snap
+++ b/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_base64_lossy.snap
@@ -3,8 +3,8 @@ source: src/ui/line/item.rs
 expression: new_item(RG_B64_JSON_BEGIN).to_span_lines(&ctx)
 ---
 [
-    Spans(
-        [
+    Line {
+        spans: [
             Span {
                 content: "./a/fo�o",
                 style: Style {
@@ -12,10 +12,12 @@ expression: new_item(RG_B64_JSON_BEGIN).to_span_lines(&ctx)
                         Magenta,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
+        alignment: None,
+    },
 ]

--- a/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_base64_lossy_confirm_replacement-2.snap
+++ b/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_base64_lossy_confirm_replacement-2.snap
@@ -3,17 +3,19 @@ source: src/ui/line/item.rs
 expression: new_item(RG_B64_JSON_END).to_span_lines(&ctx)
 ---
 [
-    Spans(
-        [
+    Line {
+        spans: [
             Span {
                 content: "",
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
+        alignment: None,
+    },
 ]

--- a/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_base64_lossy_confirm_replacement-3.snap
+++ b/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_base64_lossy_confirm_replacement-3.snap
@@ -3,8 +3,8 @@ source: src/ui/line/item.rs
 expression: new_item(RG_B64_JSON_MATCH).to_span_lines(&ctx)
 ---
 [
-    Spans(
-        [
+    Line {
+        spans: [
             Span {
                 content: "197:",
                 style: Style {
@@ -12,8 +12,9 @@ expression: new_item(RG_B64_JSON_MATCH).to_span_lines(&ctx)
                         DarkGray,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -21,8 +22,9 @@ expression: new_item(RG_B64_JSON_MATCH).to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -32,8 +34,9 @@ expression: new_item(RG_B64_JSON_MATCH).to_span_lines(&ctx)
                         Green,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -41,8 +44,9 @@ expression: new_item(RG_B64_JSON_MATCH).to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -52,8 +56,9 @@ expression: new_item(RG_B64_JSON_MATCH).to_span_lines(&ctx)
                         Green,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -61,10 +66,12 @@ expression: new_item(RG_B64_JSON_MATCH).to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
+        alignment: None,
+    },
 ]

--- a/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_base64_lossy_confirm_replacement-4.snap
+++ b/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_base64_lossy_confirm_replacement-4.snap
@@ -3,8 +3,8 @@ source: src/ui/line/item.rs
 expression: new_item(RG_B64_JSON_CONTEXT).to_span_lines(&ctx)
 ---
 [
-    Spans(
-        [
+    Line {
+        spans: [
             Span {
                 content: "198:",
                 style: Style {
@@ -12,8 +12,9 @@ expression: new_item(RG_B64_JSON_CONTEXT).to_span_lines(&ctx)
                         DarkGray,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -21,10 +22,12 @@ expression: new_item(RG_B64_JSON_CONTEXT).to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
+        alignment: None,
+    },
 ]

--- a/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_base64_lossy_confirm_replacement.snap
+++ b/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_base64_lossy_confirm_replacement.snap
@@ -3,8 +3,8 @@ source: src/ui/line/item.rs
 expression: new_item(RG_B64_JSON_BEGIN).to_span_lines(&ctx)
 ---
 [
-    Spans(
-        [
+    Line {
+        spans: [
             Span {
                 content: "./a/fo�o",
                 style: Style {
@@ -12,10 +12,12 @@ expression: new_item(RG_B64_JSON_BEGIN).to_span_lines(&ctx)
                         Magenta,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
+        alignment: None,
+    },
 ]

--- a/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_base64_lossy_input_replacement-2.snap
+++ b/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_base64_lossy_input_replacement-2.snap
@@ -3,17 +3,19 @@ source: src/ui/line/item.rs
 expression: new_item(RG_B64_JSON_END).to_span_lines(&ctx)
 ---
 [
-    Spans(
-        [
+    Line {
+        spans: [
             Span {
                 content: "",
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
+        alignment: None,
+    },
 ]

--- a/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_base64_lossy_input_replacement-3.snap
+++ b/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_base64_lossy_input_replacement-3.snap
@@ -3,8 +3,8 @@ source: src/ui/line/item.rs
 expression: new_item(RG_B64_JSON_MATCH).to_span_lines(&ctx)
 ---
 [
-    Spans(
-        [
+    Line {
+        spans: [
             Span {
                 content: "197:",
                 style: Style {
@@ -12,8 +12,9 @@ expression: new_item(RG_B64_JSON_MATCH).to_span_lines(&ctx)
                         DarkGray,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -21,8 +22,9 @@ expression: new_item(RG_B64_JSON_MATCH).to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -32,8 +34,9 @@ expression: new_item(RG_B64_JSON_MATCH).to_span_lines(&ctx)
                         Red,
                     ),
                     bg: None,
+                    underline_color: None,
                     add_modifier: CROSSED_OUT,
-                    sub_modifier: (empty),
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -43,8 +46,9 @@ expression: new_item(RG_B64_JSON_MATCH).to_span_lines(&ctx)
                         Green,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -52,8 +56,9 @@ expression: new_item(RG_B64_JSON_MATCH).to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -63,8 +68,9 @@ expression: new_item(RG_B64_JSON_MATCH).to_span_lines(&ctx)
                         Red,
                     ),
                     bg: None,
+                    underline_color: None,
                     add_modifier: CROSSED_OUT,
-                    sub_modifier: (empty),
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -74,8 +80,9 @@ expression: new_item(RG_B64_JSON_MATCH).to_span_lines(&ctx)
                         Green,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -83,10 +90,12 @@ expression: new_item(RG_B64_JSON_MATCH).to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
+        alignment: None,
+    },
 ]

--- a/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_base64_lossy_input_replacement-4.snap
+++ b/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_base64_lossy_input_replacement-4.snap
@@ -3,8 +3,8 @@ source: src/ui/line/item.rs
 expression: new_item(RG_B64_JSON_CONTEXT).to_span_lines(&ctx)
 ---
 [
-    Spans(
-        [
+    Line {
+        spans: [
             Span {
                 content: "198:",
                 style: Style {
@@ -12,8 +12,9 @@ expression: new_item(RG_B64_JSON_CONTEXT).to_span_lines(&ctx)
                         DarkGray,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -21,10 +22,12 @@ expression: new_item(RG_B64_JSON_CONTEXT).to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
+        alignment: None,
+    },
 ]

--- a/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_base64_lossy_input_replacement.snap
+++ b/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_base64_lossy_input_replacement.snap
@@ -3,8 +3,8 @@ source: src/ui/line/item.rs
 expression: new_item(RG_B64_JSON_BEGIN).to_span_lines(&ctx)
 ---
 [
-    Spans(
-        [
+    Line {
+        spans: [
             Span {
                 content: "./a/fo�o",
                 style: Style {
@@ -12,10 +12,12 @@ expression: new_item(RG_B64_JSON_BEGIN).to_span_lines(&ctx)
                         Magenta,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
+        alignment: None,
+    },
 ]

--- a/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_base64_lossy_selected-2.snap
+++ b/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_base64_lossy_selected-2.snap
@@ -3,17 +3,19 @@ source: src/ui/line/item.rs
 expression: new_item(RG_B64_JSON_END).to_span_lines(&ctx)
 ---
 [
-    Spans(
-        [
+    Line {
+        spans: [
             Span {
                 content: "",
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
+        alignment: None,
+    },
 ]

--- a/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_base64_lossy_selected-3.snap
+++ b/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_base64_lossy_selected-3.snap
@@ -3,8 +3,8 @@ source: src/ui/line/item.rs
 expression: new_item(RG_B64_JSON_MATCH).to_span_lines(&ctx)
 ---
 [
-    Spans(
-        [
+    Line {
+        spans: [
             Span {
                 content: "197:",
                 style: Style {
@@ -12,8 +12,9 @@ expression: new_item(RG_B64_JSON_MATCH).to_span_lines(&ctx)
                         Yellow,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -23,8 +24,9 @@ expression: new_item(RG_B64_JSON_MATCH).to_span_lines(&ctx)
                         Yellow,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -36,8 +38,9 @@ expression: new_item(RG_B64_JSON_MATCH).to_span_lines(&ctx)
                     bg: Some(
                         Yellow,
                     ),
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -47,8 +50,9 @@ expression: new_item(RG_B64_JSON_MATCH).to_span_lines(&ctx)
                         Yellow,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -60,8 +64,9 @@ expression: new_item(RG_B64_JSON_MATCH).to_span_lines(&ctx)
                     bg: Some(
                         Red,
                     ),
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -71,10 +76,12 @@ expression: new_item(RG_B64_JSON_MATCH).to_span_lines(&ctx)
                         Yellow,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
+        alignment: None,
+    },
 ]

--- a/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_base64_lossy_selected-4.snap
+++ b/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_base64_lossy_selected-4.snap
@@ -3,8 +3,8 @@ source: src/ui/line/item.rs
 expression: new_item(RG_B64_JSON_CONTEXT).to_span_lines(&ctx)
 ---
 [
-    Spans(
-        [
+    Line {
+        spans: [
             Span {
                 content: "198:",
                 style: Style {
@@ -12,8 +12,9 @@ expression: new_item(RG_B64_JSON_CONTEXT).to_span_lines(&ctx)
                         Yellow,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -23,10 +24,12 @@ expression: new_item(RG_B64_JSON_CONTEXT).to_span_lines(&ctx)
                         Yellow,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
+        alignment: None,
+    },
 ]

--- a/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_base64_lossy_selected.snap
+++ b/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_base64_lossy_selected.snap
@@ -3,8 +3,8 @@ source: src/ui/line/item.rs
 expression: new_item(RG_B64_JSON_BEGIN).to_span_lines(&ctx)
 ---
 [
-    Spans(
-        [
+    Line {
+        spans: [
             Span {
                 content: "./a/fo�o",
                 style: Style {
@@ -14,10 +14,12 @@ expression: new_item(RG_B64_JSON_BEGIN).to_span_lines(&ctx)
                     bg: Some(
                         Yellow,
                     ),
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
+        alignment: None,
+    },
 ]

--- a/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_deselected_submatch.snap
+++ b/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_deselected_submatch.snap
@@ -3,8 +3,8 @@ source: src/ui/line/item.rs
 expression: item.to_span_lines(&ctx)
 ---
 [
-    Spans(
-        [
+    Line {
+        spans: [
             Span {
                 content: "197:",
                 style: Style {
@@ -12,8 +12,9 @@ expression: item.to_span_lines(&ctx)
                         Yellow,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -23,8 +24,9 @@ expression: item.to_span_lines(&ctx)
                         Yellow,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -36,8 +38,9 @@ expression: item.to_span_lines(&ctx)
                     bg: Some(
                         DarkGray,
                     ),
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -47,8 +50,9 @@ expression: item.to_span_lines(&ctx)
                         Yellow,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -60,8 +64,9 @@ expression: item.to_span_lines(&ctx)
                     bg: Some(
                         Red,
                     ),
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -71,10 +76,12 @@ expression: item.to_span_lines(&ctx)
                         Yellow,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
+        alignment: None,
+    },
 ]

--- a/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_deselected_submatch_confirm_replacement.snap
+++ b/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_deselected_submatch_confirm_replacement.snap
@@ -3,8 +3,8 @@ source: src/ui/line/item.rs
 expression: item.to_span_lines(&ctx)
 ---
 [
-    Spans(
-        [
+    Line {
+        spans: [
             Span {
                 content: "197:",
                 style: Style {
@@ -12,8 +12,9 @@ expression: item.to_span_lines(&ctx)
                         DarkGray,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -21,8 +22,9 @@ expression: item.to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -30,8 +32,9 @@ expression: item.to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -39,8 +42,9 @@ expression: item.to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -50,8 +54,9 @@ expression: item.to_span_lines(&ctx)
                         Green,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -59,10 +64,12 @@ expression: item.to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
+        alignment: None,
+    },
 ]

--- a/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_deselected_submatch_input_replacement.snap
+++ b/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_deselected_submatch_input_replacement.snap
@@ -3,8 +3,8 @@ source: src/ui/line/item.rs
 expression: item.to_span_lines(&ctx)
 ---
 [
-    Spans(
-        [
+    Line {
+        spans: [
             Span {
                 content: "197:",
                 style: Style {
@@ -12,8 +12,9 @@ expression: item.to_span_lines(&ctx)
                         DarkGray,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -21,8 +22,9 @@ expression: item.to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -30,8 +32,9 @@ expression: item.to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -39,8 +42,9 @@ expression: item.to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -50,8 +54,9 @@ expression: item.to_span_lines(&ctx)
                         Red,
                     ),
                     bg: None,
+                    underline_color: None,
                     add_modifier: CROSSED_OUT,
-                    sub_modifier: (empty),
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -61,8 +66,9 @@ expression: item.to_span_lines(&ctx)
                         Green,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -70,10 +76,12 @@ expression: item.to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
+        alignment: None,
+    },
 ]

--- a/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_multiline_matches.snap
+++ b/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_multiline_matches.snap
@@ -3,8 +3,8 @@ source: src/ui/line/item.rs
 expression: new_item(RG_JSON_MATCH_MULTILINE).to_span_lines(&ctx)
 ---
 [
-    Spans(
-        [
+    Line {
+        spans: [
             Span {
                 content: "3:",
                 style: Style {
@@ -12,8 +12,9 @@ expression: new_item(RG_JSON_MATCH_MULTILINE).to_span_lines(&ctx)
                         DarkGray,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -21,8 +22,9 @@ expression: new_item(RG_JSON_MATCH_MULTILINE).to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -34,14 +36,16 @@ expression: new_item(RG_JSON_MATCH_MULTILINE).to_span_lines(&ctx)
                     bg: Some(
                         Red,
                     ),
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
-    Spans(
-        [
+        alignment: None,
+    },
+    Line {
+        spans: [
             Span {
                 content: "4:",
                 style: Style {
@@ -49,8 +53,9 @@ expression: new_item(RG_JSON_MATCH_MULTILINE).to_span_lines(&ctx)
                         DarkGray,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -62,14 +67,16 @@ expression: new_item(RG_JSON_MATCH_MULTILINE).to_span_lines(&ctx)
                     bg: Some(
                         Red,
                     ),
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
-    Spans(
-        [
+        alignment: None,
+    },
+    Line {
+        spans: [
             Span {
                 content: "5:",
                 style: Style {
@@ -77,8 +84,9 @@ expression: new_item(RG_JSON_MATCH_MULTILINE).to_span_lines(&ctx)
                         DarkGray,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -90,8 +98,9 @@ expression: new_item(RG_JSON_MATCH_MULTILINE).to_span_lines(&ctx)
                     bg: Some(
                         Red,
                     ),
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -99,8 +108,9 @@ expression: new_item(RG_JSON_MATCH_MULTILINE).to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -112,8 +122,9 @@ expression: new_item(RG_JSON_MATCH_MULTILINE).to_span_lines(&ctx)
                     bg: Some(
                         Red,
                     ),
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -121,10 +132,12 @@ expression: new_item(RG_JSON_MATCH_MULTILINE).to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
+        alignment: None,
+    },
 ]

--- a/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_multiline_replacement.snap
+++ b/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_multiline_replacement.snap
@@ -3,8 +3,8 @@ source: src/ui/line/item.rs
 expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
 ---
 [
-    Spans(
-        [
+    Line {
+        spans: [
             Span {
                 content: "197:",
                 style: Style {
@@ -12,8 +12,9 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                         DarkGray,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -21,8 +22,9 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -32,8 +34,9 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                         Red,
                     ),
                     bg: None,
+                    underline_color: None,
                     add_modifier: CROSSED_OUT,
-                    sub_modifier: (empty),
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -43,14 +46,16 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                         Green,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
-    Spans(
-        [
+        alignment: None,
+    },
+    Line {
+        spans: [
             Span {
                 content: "+:",
                 style: Style {
@@ -58,8 +63,9 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                         DarkGray,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -69,14 +75,16 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                         Green,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
-    Spans(
-        [
+        alignment: None,
+    },
+    Line {
+        spans: [
             Span {
                 content: "+:",
                 style: Style {
@@ -84,8 +92,9 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                         DarkGray,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -95,8 +104,9 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                         Green,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -104,8 +114,9 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -115,8 +126,9 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                         Red,
                     ),
                     bg: None,
+                    underline_color: None,
                     add_modifier: CROSSED_OUT,
-                    sub_modifier: (empty),
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -126,14 +138,16 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                         Green,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
-    Spans(
-        [
+        alignment: None,
+    },
+    Line {
+        spans: [
             Span {
                 content: "+:",
                 style: Style {
@@ -141,8 +155,9 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                         DarkGray,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -152,14 +167,16 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                         Green,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
-    Spans(
-        [
+        alignment: None,
+    },
+    Line {
+        spans: [
             Span {
                 content: "+:",
                 style: Style {
@@ -167,8 +184,9 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                         DarkGray,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -178,8 +196,9 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                         Green,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -187,10 +206,12 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
+        alignment: None,
+    },
 ]

--- a/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_text-2.snap
+++ b/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_text-2.snap
@@ -3,8 +3,8 @@ source: src/ui/line/item.rs
 expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
 ---
 [
-    Spans(
-        [
+    Line {
+        spans: [
             Span {
                 content: "197:",
                 style: Style {
@@ -12,8 +12,9 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                         DarkGray,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -21,8 +22,9 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -34,8 +36,9 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                     bg: Some(
                         Red,
                     ),
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -43,8 +46,9 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -56,8 +60,9 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                     bg: Some(
                         Red,
                     ),
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -65,10 +70,12 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
+        alignment: None,
+    },
 ]

--- a/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_text-3.snap
+++ b/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_text-3.snap
@@ -3,8 +3,8 @@ source: src/ui/line/item.rs
 expression: new_item(RG_JSON_CONTEXT).to_span_lines(&ctx)
 ---
 [
-    Spans(
-        [
+    Line {
+        spans: [
             Span {
                 content: "198:",
                 style: Style {
@@ -12,8 +12,9 @@ expression: new_item(RG_JSON_CONTEXT).to_span_lines(&ctx)
                         DarkGray,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -21,10 +22,12 @@ expression: new_item(RG_JSON_CONTEXT).to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
+        alignment: None,
+    },
 ]

--- a/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_text-4.snap
+++ b/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_text-4.snap
@@ -3,17 +3,19 @@ source: src/ui/line/item.rs
 expression: new_item(RG_JSON_END).to_span_lines(&ctx)
 ---
 [
-    Spans(
-        [
+    Line {
+        spans: [
             Span {
                 content: "",
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
+        alignment: None,
+    },
 ]

--- a/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_text.snap
+++ b/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_text.snap
@@ -3,8 +3,8 @@ source: src/ui/line/item.rs
 expression: new_item(RG_JSON_BEGIN).to_span_lines(&ctx)
 ---
 [
-    Spans(
-        [
+    Line {
+        spans: [
             Span {
                 content: "src/model/item.rs",
                 style: Style {
@@ -12,10 +12,12 @@ expression: new_item(RG_JSON_BEGIN).to_span_lines(&ctx)
                         Magenta,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
+        alignment: None,
+    },
 ]

--- a/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_text_confirm_replacement-2.snap
+++ b/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_text_confirm_replacement-2.snap
@@ -3,8 +3,8 @@ source: src/ui/line/item.rs
 expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
 ---
 [
-    Spans(
-        [
+    Line {
+        spans: [
             Span {
                 content: "197:",
                 style: Style {
@@ -12,8 +12,9 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                         DarkGray,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -21,8 +22,9 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -32,8 +34,9 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                         Green,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -41,8 +44,9 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -52,8 +56,9 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                         Green,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -61,10 +66,12 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
+        alignment: None,
+    },
 ]

--- a/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_text_confirm_replacement-3.snap
+++ b/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_text_confirm_replacement-3.snap
@@ -3,8 +3,8 @@ source: src/ui/line/item.rs
 expression: new_item(RG_JSON_CONTEXT).to_span_lines(&ctx)
 ---
 [
-    Spans(
-        [
+    Line {
+        spans: [
             Span {
                 content: "198:",
                 style: Style {
@@ -12,8 +12,9 @@ expression: new_item(RG_JSON_CONTEXT).to_span_lines(&ctx)
                         DarkGray,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -21,10 +22,12 @@ expression: new_item(RG_JSON_CONTEXT).to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
+        alignment: None,
+    },
 ]

--- a/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_text_confirm_replacement-4.snap
+++ b/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_text_confirm_replacement-4.snap
@@ -3,17 +3,19 @@ source: src/ui/line/item.rs
 expression: new_item(RG_JSON_END).to_span_lines(&ctx)
 ---
 [
-    Spans(
-        [
+    Line {
+        spans: [
             Span {
                 content: "",
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
+        alignment: None,
+    },
 ]

--- a/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_text_confirm_replacement.snap
+++ b/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_text_confirm_replacement.snap
@@ -3,8 +3,8 @@ source: src/ui/line/item.rs
 expression: new_item(RG_JSON_BEGIN).to_span_lines(&ctx)
 ---
 [
-    Spans(
-        [
+    Line {
+        spans: [
             Span {
                 content: "src/model/item.rs",
                 style: Style {
@@ -12,10 +12,12 @@ expression: new_item(RG_JSON_BEGIN).to_span_lines(&ctx)
                         Magenta,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
+        alignment: None,
+    },
 ]

--- a/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_text_confirm_replacement_and_capture_pattern-2.snap
+++ b/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_text_confirm_replacement_and_capture_pattern-2.snap
@@ -3,8 +3,8 @@ source: src/ui/line/item.rs
 expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
 ---
 [
-    Spans(
-        [
+    Line {
+        spans: [
             Span {
                 content: "197:",
                 style: Style {
@@ -12,8 +12,9 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                         DarkGray,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -21,8 +22,9 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -32,8 +34,9 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                         Green,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -41,8 +44,9 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -52,8 +56,9 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                         Green,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -61,10 +66,12 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
+        alignment: None,
+    },
 ]

--- a/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_text_confirm_replacement_and_capture_pattern-3.snap
+++ b/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_text_confirm_replacement_and_capture_pattern-3.snap
@@ -3,8 +3,8 @@ source: src/ui/line/item.rs
 expression: new_item(RG_JSON_CONTEXT).to_span_lines(&ctx)
 ---
 [
-    Spans(
-        [
+    Line {
+        spans: [
             Span {
                 content: "198:",
                 style: Style {
@@ -12,8 +12,9 @@ expression: new_item(RG_JSON_CONTEXT).to_span_lines(&ctx)
                         DarkGray,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -21,10 +22,12 @@ expression: new_item(RG_JSON_CONTEXT).to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
+        alignment: None,
+    },
 ]

--- a/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_text_confirm_replacement_and_capture_pattern-4.snap
+++ b/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_text_confirm_replacement_and_capture_pattern-4.snap
@@ -3,17 +3,19 @@ source: src/ui/line/item.rs
 expression: new_item(RG_JSON_END).to_span_lines(&ctx)
 ---
 [
-    Spans(
-        [
+    Line {
+        spans: [
             Span {
                 content: "",
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
+        alignment: None,
+    },
 ]

--- a/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_text_confirm_replacement_and_capture_pattern.snap
+++ b/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_text_confirm_replacement_and_capture_pattern.snap
@@ -3,8 +3,8 @@ source: src/ui/line/item.rs
 expression: new_item(RG_JSON_BEGIN).to_span_lines(&ctx)
 ---
 [
-    Spans(
-        [
+    Line {
+        spans: [
             Span {
                 content: "src/model/item.rs",
                 style: Style {
@@ -12,10 +12,12 @@ expression: new_item(RG_JSON_BEGIN).to_span_lines(&ctx)
                         Magenta,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
+        alignment: None,
+    },
 ]

--- a/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_text_input_replacement-2.snap
+++ b/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_text_input_replacement-2.snap
@@ -3,8 +3,8 @@ source: src/ui/line/item.rs
 expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
 ---
 [
-    Spans(
-        [
+    Line {
+        spans: [
             Span {
                 content: "197:",
                 style: Style {
@@ -12,8 +12,9 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                         DarkGray,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -21,8 +22,9 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -32,8 +34,9 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                         Red,
                     ),
                     bg: None,
+                    underline_color: None,
                     add_modifier: CROSSED_OUT,
-                    sub_modifier: (empty),
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -43,8 +46,9 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                         Green,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -52,8 +56,9 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -63,8 +68,9 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                         Red,
                     ),
                     bg: None,
+                    underline_color: None,
                     add_modifier: CROSSED_OUT,
-                    sub_modifier: (empty),
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -74,8 +80,9 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                         Green,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -83,10 +90,12 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
+        alignment: None,
+    },
 ]

--- a/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_text_input_replacement-3.snap
+++ b/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_text_input_replacement-3.snap
@@ -3,8 +3,8 @@ source: src/ui/line/item.rs
 expression: new_item(RG_JSON_CONTEXT).to_span_lines(&ctx)
 ---
 [
-    Spans(
-        [
+    Line {
+        spans: [
             Span {
                 content: "198:",
                 style: Style {
@@ -12,8 +12,9 @@ expression: new_item(RG_JSON_CONTEXT).to_span_lines(&ctx)
                         DarkGray,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -21,10 +22,12 @@ expression: new_item(RG_JSON_CONTEXT).to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
+        alignment: None,
+    },
 ]

--- a/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_text_input_replacement-4.snap
+++ b/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_text_input_replacement-4.snap
@@ -3,17 +3,19 @@ source: src/ui/line/item.rs
 expression: new_item(RG_JSON_END).to_span_lines(&ctx)
 ---
 [
-    Spans(
-        [
+    Line {
+        spans: [
             Span {
                 content: "",
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
+        alignment: None,
+    },
 ]

--- a/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_text_input_replacement.snap
+++ b/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_text_input_replacement.snap
@@ -3,8 +3,8 @@ source: src/ui/line/item.rs
 expression: new_item(RG_JSON_BEGIN).to_span_lines(&ctx)
 ---
 [
-    Spans(
-        [
+    Line {
+        spans: [
             Span {
                 content: "src/model/item.rs",
                 style: Style {
@@ -12,10 +12,12 @@ expression: new_item(RG_JSON_BEGIN).to_span_lines(&ctx)
                         Magenta,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
+        alignment: None,
+    },
 ]

--- a/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_text_input_replacement_and_capture_pattern-2.snap
+++ b/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_text_input_replacement_and_capture_pattern-2.snap
@@ -3,8 +3,8 @@ source: src/ui/line/item.rs
 expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
 ---
 [
-    Spans(
-        [
+    Line {
+        spans: [
             Span {
                 content: "197:",
                 style: Style {
@@ -12,8 +12,9 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                         DarkGray,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -21,8 +22,9 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -32,8 +34,9 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                         Red,
                     ),
                     bg: None,
+                    underline_color: None,
                     add_modifier: CROSSED_OUT,
-                    sub_modifier: (empty),
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -43,8 +46,9 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                         Green,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -52,8 +56,9 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -63,8 +68,9 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                         Red,
                     ),
                     bg: None,
+                    underline_color: None,
                     add_modifier: CROSSED_OUT,
-                    sub_modifier: (empty),
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -74,8 +80,9 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                         Green,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -83,10 +90,12 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
+        alignment: None,
+    },
 ]

--- a/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_text_input_replacement_and_capture_pattern-3.snap
+++ b/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_text_input_replacement_and_capture_pattern-3.snap
@@ -3,8 +3,8 @@ source: src/ui/line/item.rs
 expression: new_item(RG_JSON_CONTEXT).to_span_lines(&ctx)
 ---
 [
-    Spans(
-        [
+    Line {
+        spans: [
             Span {
                 content: "198:",
                 style: Style {
@@ -12,8 +12,9 @@ expression: new_item(RG_JSON_CONTEXT).to_span_lines(&ctx)
                         DarkGray,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -21,10 +22,12 @@ expression: new_item(RG_JSON_CONTEXT).to_span_lines(&ctx)
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
+        alignment: None,
+    },
 ]

--- a/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_text_input_replacement_and_capture_pattern-4.snap
+++ b/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_text_input_replacement_and_capture_pattern-4.snap
@@ -3,17 +3,19 @@ source: src/ui/line/item.rs
 expression: new_item(RG_JSON_END).to_span_lines(&ctx)
 ---
 [
-    Spans(
-        [
+    Line {
+        spans: [
             Span {
                 content: "",
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
+        alignment: None,
+    },
 ]

--- a/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_text_input_replacement_and_capture_pattern.snap
+++ b/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_text_input_replacement_and_capture_pattern.snap
@@ -3,8 +3,8 @@ source: src/ui/line/item.rs
 expression: new_item(RG_JSON_BEGIN).to_span_lines(&ctx)
 ---
 [
-    Spans(
-        [
+    Line {
+        spans: [
             Span {
                 content: "src/model/item.rs",
                 style: Style {
@@ -12,10 +12,12 @@ expression: new_item(RG_JSON_BEGIN).to_span_lines(&ctx)
                         Magenta,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
+        alignment: None,
+    },
 ]

--- a/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_text_selected-2.snap
+++ b/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_text_selected-2.snap
@@ -3,8 +3,8 @@ source: src/ui/line/item.rs
 expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
 ---
 [
-    Spans(
-        [
+    Line {
+        spans: [
             Span {
                 content: "197:",
                 style: Style {
@@ -12,8 +12,9 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                         Yellow,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -23,8 +24,9 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                         Yellow,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -36,8 +38,9 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                     bg: Some(
                         Yellow,
                     ),
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -47,8 +50,9 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                         Yellow,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -60,8 +64,9 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                     bg: Some(
                         Red,
                     ),
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -71,10 +76,12 @@ expression: new_item(RG_JSON_MATCH).to_span_lines(&ctx)
                         Yellow,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
+        alignment: None,
+    },
 ]

--- a/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_text_selected-3.snap
+++ b/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_text_selected-3.snap
@@ -3,8 +3,8 @@ source: src/ui/line/item.rs
 expression: new_item(RG_JSON_CONTEXT).to_span_lines(&ctx)
 ---
 [
-    Spans(
-        [
+    Line {
+        spans: [
             Span {
                 content: "198:",
                 style: Style {
@@ -12,8 +12,9 @@ expression: new_item(RG_JSON_CONTEXT).to_span_lines(&ctx)
                         Yellow,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
             Span {
@@ -23,10 +24,12 @@ expression: new_item(RG_JSON_CONTEXT).to_span_lines(&ctx)
                         Yellow,
                     ),
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
+        alignment: None,
+    },
 ]

--- a/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_text_selected-4.snap
+++ b/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_text_selected-4.snap
@@ -3,17 +3,19 @@ source: src/ui/line/item.rs
 expression: new_item(RG_JSON_END).to_span_lines(&ctx)
 ---
 [
-    Spans(
-        [
+    Line {
+        spans: [
             Span {
                 content: "",
                 style: Style {
                     fg: None,
                     bg: None,
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
+        alignment: None,
+    },
 ]

--- a/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_text_selected.snap
+++ b/src/ui/line/snapshots/rgr__ui__line__item__tests__to_span_lines_with_text_selected.snap
@@ -3,8 +3,8 @@ source: src/ui/line/item.rs
 expression: new_item(RG_JSON_BEGIN).to_span_lines(&ctx)
 ---
 [
-    Spans(
-        [
+    Line {
+        spans: [
             Span {
                 content: "src/model/item.rs",
                 style: Style {
@@ -14,10 +14,12 @@ expression: new_item(RG_JSON_BEGIN).to_span_lines(&ctx)
                     bg: Some(
                         Yellow,
                     ),
-                    add_modifier: (empty),
-                    sub_modifier: (empty),
+                    underline_color: None,
+                    add_modifier: NONE,
+                    sub_modifier: NONE,
                 },
             },
         ],
-    ),
+        alignment: None,
+    },
 ]

--- a/src/ui/line/sub_item.rs
+++ b/src/ui/line/sub_item.rs
@@ -1,5 +1,5 @@
-use tui::style::{Color, Modifier, Style};
-use tui::text::Span;
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::Span;
 
 use crate::model::Printable;
 use crate::rg::de::SubMatch;

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -1,5 +1,5 @@
+use ratatui::layout::Rect;
 use regex::bytes::Regex;
-use tui::layout::Rect;
 
 use crate::model::PrintableStyle;
 use crate::ui::app::{AppListState, AppUiState};

--- a/src/ui/tui.rs
+++ b/src/ui/tui.rs
@@ -7,12 +7,12 @@ use anyhow::Result;
 use crossterm::event::{self, Event, KeyCode};
 use crossterm::execute;
 use crossterm::terminal::{self, EnterAlternateScreen, LeaveAlternateScreen};
+use ratatui::backend::CrosstermBackend;
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Style};
+use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
+use ratatui::Terminal;
 use regex::bytes::Regex;
-use tui::backend::CrosstermBackend;
-use tui::layout::Rect;
-use tui::style::{Color, Style};
-use tui::widgets::{Block, Borders, Paragraph, Wrap};
-use tui::Terminal;
 
 use crate::model::ReplacementCriteria;
 use crate::rg::de::RgMessage;


### PR DESCRIPTION
[tui-rs](https://github.com/fdehau/tui-rs) is unmaintained.
This switches the dependency to a maintained fork called `ratatui`.